### PR TITLE
PointConv + Linear Layers Fusion and using KNN Inverse Indices

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ setup.sh
 
 7. To enable GPU-based KNN computation, set `post_knn: true` in the configuration file. Refer to [`train_ScanNet_DDP_WarmUP.py`](./train_ScanNet_DDP_WarmP.py) for an example implementation, Load data (`features`, `pointclouds`, `target`, `norms`, `points_stored`), Compute kNN edges using `compute_knn_packed()`, Prepare edges for further processing using `prepare()`
 
+8. To enable optimized PointConv CUDA kernels for saving peak GPU memory usage, set `USE_CUDA_KERNEL: True` and `PCONV_OPT: True` in the configuration file. Refer to ['configPCF_Opt_10cm.yaml'](./configs/configPCF_Opt_10cm.yaml). Use the fused PointConv and Linear layer forward and backward kernels, Compute kNN Inverse mapping indices for all the edges, use the inverse indices in the backward kernel to compute gradients.
+
 ### Evaluation
 
 <!-- (Obselete Please download the pretrain weights of the models at [here](https://drive.google.com/file/d/1BShjM0PydlEX-bE7k3-fg2UBORpwUeWR/view?usp=sharing)) -->

--- a/configs/configPCF_10cm.yaml
+++ b/configs/configPCF_10cm.yaml
@@ -1,9 +1,9 @@
 # See get_default_configs() in train_ScanNet_DDP_Warmup.py
 # and get_default_configs() in model_architecture.py for the meanings of those configs
 USE_CUDA_KERNEL: True
-PCONV_OPT:      False
+PCONV_OPT:      True
 BATCH_NORM:     True
-BATCH_SIZE:     16
+BATCH_SIZE:     32
 NUM_WORKERS:    2
 USE_XYZ:        True
 USE_MLP:        False

--- a/configs/configPCF_10cm.yaml
+++ b/configs/configPCF_10cm.yaml
@@ -1,8 +1,10 @@
 # See get_default_configs() in train_ScanNet_DDP_Warmup.py
 # and get_default_configs() in model_architecture.py for the meanings of those configs
+USE_CUDA_KERNEL: True
+PCONV_OPT:      False
 BATCH_NORM:     True
 BATCH_SIZE:     16
-NUM_WORKERS:    24
+NUM_WORKERS:    2
 USE_XYZ:        True
 USE_MLP:        False
 USE_WEIGHT:     True
@@ -38,9 +40,9 @@ num_heads:      8
 resblocks:      [ 0, 2, 4, 6, 6]
 resblocks_back: [ 0, 0, 0, 0, 0]
 
-train_data_path: './data/ScanNet_withNewNormal/train/*.pth'
-val_data_path:   './data/ScanNet_withNewNormal/val/*.pth'
-test_data_path:  './data/ScanNet_withNewNormal/test/*.pth'
+train_data_path: '/nfs/hpc/share/lif-grp/Datasets/ScanNet/V2/ScanNet_withNormal/train/*.pth'
+val_data_path:   '/nfs/hpc/share/lif-grp/Datasets/ScanNet/V2/ScanNet_withNormal/val/*.pth'
+test_data_path:  '/nfs/hpc/share/lif-grp/Datasets/ScanNet/V2/ScanNet_withNormal/test/*.pth'
 pretrain:        null
 optimizer:       'AdamW'
 adamw_decay:     0.05
@@ -62,7 +64,7 @@ warmup:           'linear'
 warmup_epochs:    10
 warmup_ratio:     0.00001
 
-use_tensorboard: False
+use_tensorboard: True
 model_name:      'NewPointConvFormer_10cm'
 experiment_dir:  './guided_experiment_10cm/'
 ft_experiment_dir: './ft_guided_experiment_10cm/'

--- a/configs/configPCF_Opt_10cm.yaml
+++ b/configs/configPCF_Opt_10cm.yaml
@@ -1,5 +1,7 @@
 # See get_default_configs() in train_ScanNet_DDP_Warmup.py
 # and get_default_configs() in model_architecture.py for the meanings of those configs
+USE_CUDA_KERNEL: True
+PCONV_OPT:      True
 BATCH_NORM:     True
 BATCH_SIZE:     16
 NUM_WORKERS:    24
@@ -20,6 +22,8 @@ TIME: False
 MAX_POINTS_NUM: 550000
 use_ASPP:       False
 NormalizedXYZ:  False
+
+post_knn:       True
 K_forward:      [16, 16, 16, 16, 16]
 K_propagate:    [16, 16, 16, 16, 16]
 K_self:         [16, 16, 16, 16, 16]

--- a/cpp_wrappers/cpp_pcf_kernel/pcf_cuda.cpp
+++ b/cpp_wrappers/cpp_pcf_kernel/pcf_cuda.cpp
@@ -22,7 +22,7 @@ torch::Tensor pconv_cuda_forward(
     torch::Tensor weights,
     torch::Tensor additional_features);
 
-torch::Tensor pconv_linear_cuda_forward(
+std::vector<torch::Tensor> pconv_linear_cuda_forward(
     torch::Tensor input,
     torch::Tensor neighbor_inds,
     torch::Tensor weights,
@@ -73,7 +73,7 @@ torch::Tensor pconv_forward(
     return pconv_cuda_forward(input, neighbor_inds, weights, additional_features);
 }
 
-torch::Tensor pconv_linear_forward(
+std::vector<torch::Tensor> pconv_linear_forward(
     torch::Tensor input,
     torch::Tensor neighbor_inds,
     torch::Tensor weights,

--- a/cpp_wrappers/cpp_pcf_kernel/pcf_cuda.cpp
+++ b/cpp_wrappers/cpp_pcf_kernel/pcf_cuda.cpp
@@ -38,15 +38,14 @@ std::vector<torch::Tensor> pconv_cuda_backward(
     torch::Tensor weights,
     torch::Tensor additional_features);
 
-// std::vector<torch::Tensor> pconv_linear_cuda_backward(
-//     torch::Tensor grad_output,
-//     torch::Tensor input,
-//     torch::Tensor neighbor_inds,
-//     torch::Tensor weights,
-//     torch::Tensor additional_features,
-//     torch::Tensor linear_weights,
-//     torch::Tensor linear_bias,
-//     torch::Tensor pconv_output);
+std::vector<torch::Tensor> pconv_linear_cuda_backward(
+    torch::Tensor grad_output,
+    torch::Tensor input,
+    torch::Tensor neighbor_inds,
+    torch::Tensor weights,
+    torch::Tensor additional_features,
+    torch::Tensor linear_weights,
+    torch::Tensor pconv_output);
     
 std::vector<torch::Tensor> pcf_cuda_backward(
     torch::Tensor grad_output,
@@ -108,26 +107,24 @@ std::vector<torch::Tensor> pconv_backward(
 }
 
 
-// std::vector<torch::Tensor> pconv_linear_backward(
-//     torch::Tensor grad_output,
-//     torch::Tensor input,
-//     torch::Tensor neighbor_inds,
-//     torch::Tensor weights,
-//     torch::Tensor additional_features,
-//     torch::Tensor linear_weights,
-//     torch::Tensor linear_bias,
-//     torch::Tensor pconv_output)
-// {
-//     CHECK_INPUT(grad_output);
-//     CHECK_INPUT(neighbor_inds);
-//     CHECK_INPUT(weights);
-//     CHECK_INPUT(additional_features);
-//     CHECK_INPUT(linear_weights);
-//     CHECK_INPUT(linear_bias);
-//     CHECK_INPUT(pconv_output);
-//     return pconv_linear_cuda_backward(grad_output, input, neighbor_inds, weights, additional_features,
-//                 linear_weights, linear_bias, pconv_output);
-// }
+std::vector<torch::Tensor> pconv_linear_backward(
+    torch::Tensor grad_output,
+    torch::Tensor input,
+    torch::Tensor neighbor_inds,
+    torch::Tensor weights,
+    torch::Tensor additional_features,
+    torch::Tensor linear_weights,
+    torch::Tensor pconv_output)
+{
+    CHECK_INPUT(grad_output);
+    CHECK_INPUT(neighbor_inds);
+    CHECK_INPUT(weights);
+    CHECK_INPUT(additional_features);
+    CHECK_INPUT(linear_weights);
+    CHECK_INPUT(pconv_output);
+    return pconv_linear_cuda_backward(grad_output, input, neighbor_inds, weights, additional_features,
+                linear_weights, pconv_output);
+}
 
 torch::Tensor pcf_forward(
     torch::Tensor input,
@@ -163,5 +160,5 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("pconv_forward", &pconv_forward, "PointConv forward (CUDA)");
   m.def("pconv_linear_forward", &pconv_linear_forward, "Fused PointConv+Linear forward (CUDA)");
   m.def("pconv_backward", &pconv_backward, "PointConv backward (CUDA)");
-//   m.def("pconv_linear_backward", &pconv_linear_backward, "Fused PointConv+Linear backward (CUDA)");
+  m.def("pconv_linear_backward", &pconv_linear_backward, "Fused PointConv+Linear backward (CUDA)");
 }

--- a/cpp_wrappers/cpp_pcf_kernel/pcf_cuda.cpp
+++ b/cpp_wrappers/cpp_pcf_kernel/pcf_cuda.cpp
@@ -14,13 +14,10 @@ std::vector<torch::Tensor> pconv_linear_cutlass_forward(
     torch::Tensor linear_weights,
     torch::Tensor linear_bias);
 
-
 std::vector<torch::Tensor> knn_inverse_cuda_forward(
     torch::Tensor neighbor_inds,
     const int total_points);
 
-// TODO: For now, not attempting to fuse the next downsampling linear layer because hand-written matmul 
-//       cannot compare with optimized gemm kernels. May explore using CUTLASS for that at a later time.
 torch::Tensor pcf_cuda_forward(
     torch::Tensor input,
     torch::Tensor neighbor_inds,
@@ -28,7 +25,6 @@ torch::Tensor pcf_cuda_forward(
     torch::Tensor weights
     );
 
-// Need a version for PointConv too
 torch::Tensor pconv_cuda_forward(
     torch::Tensor input,
     torch::Tensor neighbor_inds,
@@ -59,7 +55,7 @@ std::vector<torch::Tensor> pconv_linear_cuda_backward(
     torch::Tensor additional_features,
     torch::Tensor linear_weights,
     torch::Tensor pconv_output);
-    
+
 std::vector<torch::Tensor> pcf_cuda_backward(
     torch::Tensor grad_output,
     torch::Tensor input,
@@ -78,7 +74,7 @@ std::vector<torch::Tensor> pconv_linear_opt_cuda_backward(
     torch::Tensor additional_features,
     torch::Tensor linear_weights,
     torch::Tensor pconv_output);
-    
+
 #define CHECK_CUDA(x) {TORCH_CHECK(x.device().is_cuda(), #x " must be a CUDA tensor")}
 #define CHECK_CONTIGUOUS(x) {TORCH_CHECK(x.is_contiguous(), #x " must be contiguous")}
 #define CHECK_INPUT(x) CHECK_CUDA(x); CHECK_CONTIGUOUS(x)
@@ -89,7 +85,7 @@ torch::Tensor pconv_forward(
     torch::Tensor weights,
     torch::Tensor additional_features
 )
-{   
+{
     CHECK_INPUT(input);
     CHECK_INPUT(neighbor_inds);
     CHECK_INPUT(weights);
@@ -106,7 +102,7 @@ std::vector<torch::Tensor> pconv_linear_forward(
     torch::Tensor linear_weights,
     torch::Tensor linear_bias
 )
-{   
+{
     CHECK_INPUT(input);
     CHECK_INPUT(neighbor_inds);
     CHECK_INPUT(weights);
@@ -130,7 +126,6 @@ std::vector<torch::Tensor> pconv_backward(
     CHECK_INPUT(additional_features);
     return pconv_cuda_backward(grad_output,input, neighbor_inds, weights, additional_features);
 }
-
 
 std::vector<torch::Tensor> pconv_linear_backward(
     torch::Tensor grad_output,
@@ -156,7 +151,7 @@ torch::Tensor pcf_forward(
     torch::Tensor neighbor_inds,
     torch::Tensor guidance,
     torch::Tensor weights
-) 
+)
 {
     CHECK_INPUT(input);
     CHECK_INPUT(neighbor_inds);
@@ -181,11 +176,11 @@ std::vector<torch::Tensor> pcf_backward(
 
 std::vector<torch::Tensor> compute_knn_inverse(
     torch::Tensor neighbor_inds,
-    const int total_points) 
+    const int total_points)
 {
     CHECK_CUDA(neighbor_inds);
     CHECK_CONTIGUOUS(neighbor_inds);
-    
+
     return knn_inverse_cuda_forward(neighbor_inds, total_points);
 }
 
@@ -213,7 +208,7 @@ std::vector<torch::Tensor> pconv_linear_opt_backward(
     CHECK_INPUT(pconv_output);
 
     return pconv_linear_opt_cuda_backward(
-        grad_output, input, inverse_neighbor, inverse_neighbor_k, 
+        grad_output, input, inverse_neighbor, inverse_neighbor_k,
         inverse_neighbor_idx, neighbor_inds, weights, additional_features,
         linear_weights, pconv_output);
 }
@@ -238,13 +233,13 @@ std::vector<torch::Tensor> pconv_linear_cutlass(
 }
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-  m.def("pcf_forward", &pcf_forward, "PCF forward (CUDA)");
-  m.def("pcf_backward", &pcf_backward, "PCF backward (CUDA)");
-  m.def("pconv_forward", &pconv_forward, "PointConv forward (CUDA)");
-  m.def("pconv_linear_forward", &pconv_linear_forward, "Fused PointConv+Linear forward (CUDA)");
-  m.def("pconv_backward", &pconv_backward, "PointConv backward (CUDA)");
-  m.def("pconv_linear_backward", &pconv_linear_backward, "Fused PointConv+Linear backward (CUDA)");
-  m.def("pconv_linear_opt_backward", &pconv_linear_opt_backward, "Optimized Fused PointConv+Linear backward (CUDA)");
-  m.def("compute_knn_inverse", &compute_knn_inverse, "Compute KNN inverse mapping (CUDA)");
-  m.def("pconv_linear_cutlass_forward", &pconv_linear_cutlass, "PConv Linear forward (CUTLASS)");
+    m.def("pcf_forward", &pcf_forward, "PCF forward (CUDA)");
+    m.def("pcf_backward", &pcf_backward, "PCF backward (CUDA)");
+    m.def("pconv_forward", &pconv_forward, "PointConv forward (CUDA)");
+    m.def("pconv_linear_forward", &pconv_linear_forward, "Fused PointConv+Linear forward (CUDA)");
+    m.def("pconv_backward", &pconv_backward, "PointConv backward (CUDA)");
+    m.def("pconv_linear_backward", &pconv_linear_backward, "Fused PointConv+Linear backward (CUDA)");
+    m.def("pconv_linear_opt_backward", &pconv_linear_opt_backward, "Optimized Fused PointConv+Linear backward (CUDA)");
+    m.def("compute_knn_inverse", &compute_knn_inverse, "Compute KNN inverse mapping (CUDA)");
+    m.def("pconv_linear_cutlass_forward", &pconv_linear_cutlass, "PConv Linear forward (CUTLASS)");
 }

--- a/cpp_wrappers/cpp_pcf_kernel/pcf_cuda.cpp
+++ b/cpp_wrappers/cpp_pcf_kernel/pcf_cuda.cpp
@@ -6,6 +6,15 @@
 
 #include <vector>
 
+std::vector<torch::Tensor> pconv_linear_cutlass_forward(
+    torch::Tensor input,
+    torch::Tensor neighbor_inds,
+    torch::Tensor weights,
+    torch::Tensor additional_features,
+    torch::Tensor linear_weights,
+    torch::Tensor linear_bias);
+
+
 std::vector<torch::Tensor> knn_inverse_cuda_forward(
     torch::Tensor neighbor_inds,
     const int total_points);
@@ -209,6 +218,25 @@ std::vector<torch::Tensor> pconv_linear_opt_backward(
         linear_weights, pconv_output);
 }
 
+std::vector<torch::Tensor> pconv_linear_cutlass(
+    torch::Tensor input,
+    torch::Tensor neighbor_inds,
+    torch::Tensor weights,
+    torch::Tensor additional_features,
+    torch::Tensor linear_weights,
+    torch::Tensor linear_bias
+)
+{
+    CHECK_INPUT(input);
+    CHECK_INPUT(neighbor_inds);
+    CHECK_INPUT(weights);
+    CHECK_INPUT(additional_features);
+    CHECK_INPUT(linear_weights);
+    CHECK_INPUT(linear_bias);
+
+    return pconv_linear_cutlass_forward(input, neighbor_inds, weights, additional_features, linear_weights, linear_bias);
+}
+
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("pcf_forward", &pcf_forward, "PCF forward (CUDA)");
   m.def("pcf_backward", &pcf_backward, "PCF backward (CUDA)");
@@ -218,4 +246,5 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("pconv_linear_backward", &pconv_linear_backward, "Fused PointConv+Linear backward (CUDA)");
   m.def("pconv_linear_opt_backward", &pconv_linear_opt_backward, "Optimized Fused PointConv+Linear backward (CUDA)");
   m.def("compute_knn_inverse", &compute_knn_inverse, "Compute KNN inverse mapping (CUDA)");
+  m.def("pconv_linear_cutlass_forward", &pconv_linear_cutlass, "PConv Linear forward (CUTLASS)");
 }

--- a/cpp_wrappers/cpp_pcf_kernel/pcf_cuda.cpp
+++ b/cpp_wrappers/cpp_pcf_kernel/pcf_cuda.cpp
@@ -22,6 +22,15 @@ torch::Tensor pconv_cuda_forward(
     torch::Tensor weights,
     torch::Tensor additional_features);
 
+torch::Tensor pconv_linear_cuda_forward(
+    torch::Tensor input,
+    torch::Tensor neighbor_inds,
+    torch::Tensor weights,
+    torch::Tensor additional_features,
+    torch::Tensor linear_weights,
+    torch::Tensor linear_bias
+);
+
 std::vector<torch::Tensor> pconv_cuda_backward(
     torch::Tensor grad_output,
     torch::Tensor input,
@@ -53,6 +62,25 @@ torch::Tensor pconv_forward(
     CHECK_INPUT(additional_features);
 
     return pconv_cuda_forward(input, neighbor_inds, weights, additional_features);
+}
+
+torch::Tensor pconv_linear_forward(
+    torch::Tensor input,
+    torch::Tensor neighbor_inds,
+    torch::Tensor weights,
+    torch::Tensor additional_features,
+    torch::Tensor linear_weights,
+    torch::Tensor linear_bias
+)
+{   
+    CHECK_INPUT(input);
+    CHECK_INPUT(neighbor_inds);
+    CHECK_INPUT(weights);
+    CHECK_INPUT(additional_features);
+    CHECK_INPUT(linear_weights);
+    CHECK_INPUT(linear_bias);
+
+    return pconv_linear_cuda_forward(input, neighbor_inds, weights, additional_features, linear_weights, linear_bias);
 }
 
 std::vector<torch::Tensor> pconv_backward(
@@ -102,5 +130,6 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("pcf_forward", &pcf_forward, "PCF forward (CUDA)");
   m.def("pcf_backward", &pcf_backward, "PCF backward (CUDA)");
   m.def("pconv_forward", &pconv_forward, "PointConv forward (CUDA)");
+  m.def("pconv_linear_forward", &pconv_linear_forward, "Fused PointConv+Linear forward (CUDA)");
   m.def("pconv_backward", &pconv_backward, "PointConv backward (CUDA)");
 }

--- a/cpp_wrappers/cpp_pcf_kernel/pcf_cuda.cpp
+++ b/cpp_wrappers/cpp_pcf_kernel/pcf_cuda.cpp
@@ -6,6 +6,10 @@
 
 #include <vector>
 
+std::vector<torch::Tensor> knn_inverse_cuda_forward(
+    torch::Tensor neighbor_inds,
+    const int total_points);
+
 // TODO: For now, not attempting to fuse the next downsampling linear layer because hand-written matmul 
 //       cannot compare with optimized gemm kernels. May explore using CUTLASS for that at a later time.
 torch::Tensor pcf_cuda_forward(
@@ -154,6 +158,16 @@ std::vector<torch::Tensor> pcf_backward(
     return pcf_cuda_backward(grad_output,input, neighbor_inds, guidance, weights);
 }
 
+std::vector<torch::Tensor> compute_knn_inverse(
+    torch::Tensor neighbor_inds,
+    const int total_points) 
+{
+    CHECK_CUDA(neighbor_inds);
+    CHECK_CONTIGUOUS(neighbor_inds);
+    
+    return knn_inverse_cuda_forward(neighbor_inds, total_points);
+}
+
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("pcf_forward", &pcf_forward, "PCF forward (CUDA)");
   m.def("pcf_backward", &pcf_backward, "PCF backward (CUDA)");
@@ -161,4 +175,5 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("pconv_linear_forward", &pconv_linear_forward, "Fused PointConv+Linear forward (CUDA)");
   m.def("pconv_backward", &pconv_backward, "PointConv backward (CUDA)");
   m.def("pconv_linear_backward", &pconv_linear_backward, "Fused PointConv+Linear backward (CUDA)");
+  m.def("compute_knn_inverse", &compute_knn_inverse, "Compute KNN inverse mapping (CUDA)");
 }

--- a/cpp_wrappers/cpp_pcf_kernel/pcf_cuda.cpp
+++ b/cpp_wrappers/cpp_pcf_kernel/pcf_cuda.cpp
@@ -37,6 +37,16 @@ std::vector<torch::Tensor> pconv_cuda_backward(
     torch::Tensor neighbor_inds,
     torch::Tensor weights,
     torch::Tensor additional_features);
+
+// std::vector<torch::Tensor> pconv_linear_cuda_backward(
+//     torch::Tensor grad_output,
+//     torch::Tensor input,
+//     torch::Tensor neighbor_inds,
+//     torch::Tensor weights,
+//     torch::Tensor additional_features,
+//     torch::Tensor linear_weights,
+//     torch::Tensor linear_bias,
+//     torch::Tensor pconv_output);
     
 std::vector<torch::Tensor> pcf_cuda_backward(
     torch::Tensor grad_output,
@@ -94,9 +104,30 @@ std::vector<torch::Tensor> pconv_backward(
     CHECK_INPUT(neighbor_inds);
     CHECK_INPUT(weights);
     CHECK_INPUT(additional_features);
-    return pconv_cuda_backward(grad_output,input, neighbor_inds, weights,additional_features);
+    return pconv_cuda_backward(grad_output,input, neighbor_inds, weights, additional_features);
 }
 
+
+// std::vector<torch::Tensor> pconv_linear_backward(
+//     torch::Tensor grad_output,
+//     torch::Tensor input,
+//     torch::Tensor neighbor_inds,
+//     torch::Tensor weights,
+//     torch::Tensor additional_features,
+//     torch::Tensor linear_weights,
+//     torch::Tensor linear_bias,
+//     torch::Tensor pconv_output)
+// {
+//     CHECK_INPUT(grad_output);
+//     CHECK_INPUT(neighbor_inds);
+//     CHECK_INPUT(weights);
+//     CHECK_INPUT(additional_features);
+//     CHECK_INPUT(linear_weights);
+//     CHECK_INPUT(linear_bias);
+//     CHECK_INPUT(pconv_output);
+//     return pconv_linear_cuda_backward(grad_output, input, neighbor_inds, weights, additional_features,
+//                 linear_weights, linear_bias, pconv_output);
+// }
 
 torch::Tensor pcf_forward(
     torch::Tensor input,
@@ -132,4 +163,5 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("pconv_forward", &pconv_forward, "PointConv forward (CUDA)");
   m.def("pconv_linear_forward", &pconv_linear_forward, "Fused PointConv+Linear forward (CUDA)");
   m.def("pconv_backward", &pconv_backward, "PointConv backward (CUDA)");
+//   m.def("pconv_linear_backward", &pconv_linear_backward, "Fused PointConv+Linear backward (CUDA)");
 }

--- a/cpp_wrappers/cpp_pcf_kernel/pcf_cuda.cpp
+++ b/cpp_wrappers/cpp_pcf_kernel/pcf_cuda.cpp
@@ -57,6 +57,18 @@ std::vector<torch::Tensor> pcf_cuda_backward(
     torch::Tensor neighbor_inds,
     torch::Tensor guidance,
     torch::Tensor weights);
+
+std::vector<torch::Tensor> pconv_linear_opt_cuda_backward(
+    torch::Tensor grad_output,
+    torch::Tensor input,
+    torch::Tensor inverse_neighbor,
+    torch::Tensor inverse_neighbor_k,
+    torch::Tensor inverse_neighbor_idx,
+    torch::Tensor neighbor_inds,
+    torch::Tensor weights,
+    torch::Tensor additional_features,
+    torch::Tensor linear_weights,
+    torch::Tensor pconv_output);
     
 #define CHECK_CUDA(x) {TORCH_CHECK(x.device().is_cuda(), #x " must be a CUDA tensor")}
 #define CHECK_CONTIGUOUS(x) {TORCH_CHECK(x.is_contiguous(), #x " must be contiguous")}
@@ -168,6 +180,35 @@ std::vector<torch::Tensor> compute_knn_inverse(
     return knn_inverse_cuda_forward(neighbor_inds, total_points);
 }
 
+std::vector<torch::Tensor> pconv_linear_opt_backward(
+    torch::Tensor grad_output,
+    torch::Tensor input,
+    torch::Tensor inverse_neighbor,
+    torch::Tensor inverse_neighbor_k,
+    torch::Tensor inverse_neighbor_idx,
+    torch::Tensor neighbor_inds,
+    torch::Tensor weights,
+    torch::Tensor additional_features,
+    torch::Tensor linear_weights,
+    torch::Tensor pconv_output)
+{
+    CHECK_INPUT(grad_output);
+    CHECK_INPUT(input);
+    CHECK_INPUT(inverse_neighbor);
+    CHECK_INPUT(inverse_neighbor_k);
+    CHECK_INPUT(inverse_neighbor_idx);
+    CHECK_INPUT(neighbor_inds);
+    CHECK_INPUT(weights);
+    CHECK_INPUT(additional_features);
+    CHECK_INPUT(linear_weights);
+    CHECK_INPUT(pconv_output);
+
+    return pconv_linear_opt_cuda_backward(
+        grad_output, input, inverse_neighbor, inverse_neighbor_k, 
+        inverse_neighbor_idx, neighbor_inds, weights, additional_features,
+        linear_weights, pconv_output);
+}
+
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("pcf_forward", &pcf_forward, "PCF forward (CUDA)");
   m.def("pcf_backward", &pcf_backward, "PCF backward (CUDA)");
@@ -175,5 +216,6 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("pconv_linear_forward", &pconv_linear_forward, "Fused PointConv+Linear forward (CUDA)");
   m.def("pconv_backward", &pconv_backward, "PointConv backward (CUDA)");
   m.def("pconv_linear_backward", &pconv_linear_backward, "Fused PointConv+Linear backward (CUDA)");
+  m.def("pconv_linear_opt_backward", &pconv_linear_opt_backward, "Optimized Fused PointConv+Linear backward (CUDA)");
   m.def("compute_knn_inverse", &compute_knn_inverse, "Compute KNN inverse mapping (CUDA)");
 }

--- a/cpp_wrappers/cpp_pcf_kernel/pcf_cuda_kernel.cu
+++ b/cpp_wrappers/cpp_pcf_kernel/pcf_cuda_kernel.cu
@@ -6,8 +6,34 @@
 #include <cuda.h>
 #include <cuda_runtime.h>
 #include <stdio.h>
-
 #include <vector>
+#include <mma.h>
+#include <cuda_fp16.h>
+
+using namespace nvcuda;
+
+__host__ __device__ inline int nextPowerOf2(int n) {
+    n--;           // Decrement n to handle the case when n is already a power of 2
+    n |= n >> 1;   // Set all bits after the highest set bit to 1
+    n |= n >> 2;   // Continue setting bits
+    n |= n >> 4;
+    n |= n >> 8;
+    n |= n >> 16;
+    return n + 1;  // Add 1 to get the next power of 2
+}
+
+// Helper function to convert float to half
+__global__ void convert_to_half(
+    const float* input,
+    half* output,
+    int size
+) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < size) {
+        output[idx] = __float2half(input[idx]);
+    }
+}
+
 
 // First goal is to get forward to work to speed up the inference
 // Second goal is to get backward to work to save GPU memory so that we can deal with 2cm better and have larger batch sizes
@@ -90,82 +116,61 @@ __global__ void pconv_cuda_forward_kernel(
    It outputs a tensor of shape B x N x (C_mid * (C_in + C_add)
    It avoids serializing the input hence faster than naive pyTorch implementation
   */
-        
+
         extern __shared__ unsigned char memory[];
         scalar_t* shared_mem = reinterpret_cast<scalar_t*>(memory);
 
-        int i, k, ii, jj, kk, iter0;
         const int B = input.size(0);
-        const int N = input.size(1);
         const int Nout = neighbor_inds.size(1);
         const int C_in = input.size(2);
         const int K = neighbor_inds.size(2);
         const int C_mid = weights.size(3);
-	const int C_add = additional_features.size(3);
-        const int increment = blockDim.x / C_mid;
+        const int C_add = additional_features.size(3);
 
-        scalar_t* shared_input = shared_mem; // Shared memory for input
-        scalar_t* shared_additional = shared_mem + K * C_in; // Shared memory for additional_features
+        // Each thread block handles one point
+        const int batch_idx = blockIdx.x / Nout;
+        const int point_idx = blockIdx.x % Nout;
+        const int tid = threadIdx.x;
 
-        /* parallelize ii and i on blocks */
-        // Supposedly blockIdx.x should go up to B * N
-        for (iter0 = blockIdx.x; iter0 < B * Nout; iter0 += gridDim.x) {
-                // ii is the index on the batch dimension
-                ii = iter0 / Nout;
-                // i is the index on the point dimension
-                i = iter0 % Nout;
-                // Suppose each point is a block, then split it into threads
-                // output channels is at least 8, C_mid is usually at least 16, so we are safe dividing on this dimension
-                // C_mid is at most 16, so for sure each C_mid gets its own thread, and maybe we have many threads for the same C_mid
-                jj = threadIdx.x / increment;
-                // Throw out the excessive threads
-                if (jj >= C_mid)
-                        continue;
+        // Shared memory
+        scalar_t* shared_input = shared_mem;
+        scalar_t* shared_additional = shared_input + K * C_in;
 
-                // Load input data into shared memory
-                for (k = threadIdx.x; k < K * C_in; k += blockDim.x) {
-                        int k_idx = k / C_in;
-                        int c_idx = k % C_in;
-                        shared_input[k] = input[ii][neighbor_inds[ii][i][k_idx]][c_idx];
+        // Load input features
+        for (int k = 0; k < K; k++) {
+                const int n_idx = neighbor_inds[batch_idx][point_idx][k];
+                for (int c = tid; c < C_in; c += blockDim.x) {
+                        shared_input[k * C_in + c] = input[batch_idx][n_idx][c];
                 }
+        }
 
-                // Load additional features into shared memory
-                if (C_add > 0) {
-                        for (k = threadIdx.x; k < K * C_add; k += blockDim.x) {
-                                int k_idx = k / C_add;
-                                int c_idx = k % C_add;
-                                shared_additional[k] = additional_features[ii][i][k_idx][c_idx];
+        // Load additional features
+        if (C_add > 0) {
+                for (int k = 0; k < K; k++) {
+                        for (int c = tid; c < C_add; c += blockDim.x) {
+                                shared_additional[k * C_add + c] = additional_features[batch_idx][point_idx][k][c];
                         }
                 }
+        }
 
-                __syncthreads(); // Synchronize threads after loading shared memory
+        __syncthreads();
 
-                // This is our main non-contiguous memory access because we need to sparse gather the input
-                // But maybe we coalesce memory across all the threads in the block?
-                scalar_t partial_sum_1 = 0.0;
-                for(kk = threadIdx.x % increment; kk < C_in; kk += increment) {
-                        #pragma unroll
-                        for (k = 0; k < K; k++) {
-                                partial_sum_1 += shared_input[k * C_in + kk] * weights[ii][i][k][jj];
-                        }
-                        output[ii][i][jj + kk * C_mid] = partial_sum_1;
-                        partial_sum_1 = 0.0;
-                }
-                if (C_add > 0) {
-                        scalar_t partial_sum_2 = 0.0;
-                        for(kk = threadIdx.x % increment; kk < C_add; kk += increment) {
-                                #pragma unroll
-                                for (k = 0; k < K; k++) {
-                                        partial_sum_2 += shared_additional[k * C_add + kk] * weights[ii][i][k][jj];
-                                }
-                                output[ii][i][jj + (kk + C_in) * C_mid] = partial_sum_2;
-                                partial_sum_2 = 0.0;
+        // PConv
+        const int total_channels = C_mid * (C_in + C_add);
+        for (int c = tid; c < total_channels; c += blockDim.x) {
+                const int mid_idx = c % C_mid;
+                const int in_idx = c / C_mid;
+
+                scalar_t sum = 0;
+                for (int k = 0; k < K; k++) {
+                        if (in_idx < C_in) {
+                                sum += shared_input[k * C_in + in_idx] * weights[batch_idx][point_idx][k][mid_idx];
+                        } else {
+                                sum += shared_additional[k * C_add + (in_idx - C_in)] * weights[batch_idx][point_idx][k][mid_idx];
                         }
                 }
-                // At this point we would have fully populated the interm array of C_mid * C_in
-
-                __syncthreads();
-	}
+                output[batch_idx][point_idx][c] = sum;
+        }
 }
 
 template <typename scalar_t>
@@ -189,93 +194,85 @@ __global__ void pconv_linear_cuda_forward_kernel(
    It outputs a tensor of shape B x N x (C_mid * (C_in + C_add)
    It avoids serializing the input hence faster than naive pyTorch implementation
   */
-        
         extern __shared__ unsigned char memory[];
         scalar_t* shared_mem = reinterpret_cast<scalar_t*>(memory);
 
-        int i, k, ii, jj, kk, iter0;
-        const int B = input.size(0);
-        const int N = input.size(1);
-        const int Nout = neighbor_inds.size(1);
-        const int C_in = input.size(2);
         const int K = neighbor_inds.size(2);
+        const int C_in = input.size(2);
         const int C_mid = weights.size(3);
-	const int C_add = additional_features.size(3);
+        const int C_add = additional_features.size(3);
         const int C_out = linear_weights.size(0);
-        const int increment = blockDim.x / C_mid;
+        
+        const int batch_idx = blockIdx.x / gridDim.y;
+        const int point_idx = blockIdx.y;
+        const int tid = threadIdx.x;
+        const int warp_id = tid / 32;
+        const int lane_id = tid % 32;
 
         // Shared memory
-        scalar_t* shared_input = shared_mem;                            // input
-        scalar_t* shared_additional = shared_mem + K * C_in;            // additional_features
-        scalar_t* shared_fused_output = shared_additional + K * C_add;  // fused output
+        scalar_t* shared_input = shared_mem;
+        scalar_t* shared_additional = shared_input + (K * C_in);
+        scalar_t* shared_weights = shared_additional + (K * C_add);
+        scalar_t* shared_intermediate = shared_weights + (K * C_mid);
 
-        /* parallelize ii and i on blocks */
-        // Supposedly blockIdx.x should go up to B * N
-        for (iter0 = blockIdx.x; iter0 < B * Nout; iter0 += gridDim.x) {
-                // ii is the index on the batch dimension
-                ii = iter0 / Nout;
-                // i is the index on the point dimension
-                i = iter0 % Nout;
-                // Suppose each point is a block, then split it into threads
-                // output channels is at least 8, C_mid is usually at least 16, so we are safe dividing on this dimension
-                // C_mid is at most 16, so for sure each C_mid gets its own thread, and maybe we have many threads for the same C_mid
-                jj = threadIdx.x / increment;
-                // Throw out the excessive threads
-                if (jj >= C_mid)
-                        continue;
+        // Load input features
+        #pragma unroll
+        for (int i = tid; i < K * C_in; i += blockDim.x) {
+                const int k = i / C_in;
+                const int c = i % C_in;
+                const int n_idx = neighbor_inds[batch_idx][point_idx][k];
+                shared_input[i] = input[batch_idx][n_idx][c];
+        }
 
-                // Load input data into shared memory
-                for (k = threadIdx.x; k < K * C_in; k += blockDim.x) {
-                        int k_idx = k / C_in;
-                        int c_idx = k % C_in;
-                        shared_input[k] = input[ii][neighbor_inds[ii][i][k_idx]][c_idx];
+        // Load additional features
+        #pragma unroll
+        for (int i = tid; i < K * C_add; i += blockDim.x) {
+                const int k = i / C_add;
+                const int c = i % C_add;
+                shared_additional[i] = additional_features[batch_idx][point_idx][k][c];
+        }
+
+        // Load weights
+        #pragma unroll
+        for (int i = tid; i < K * C_mid; i += blockDim.x) {
+                const int k = i / C_mid;
+                const int c = i % C_mid;
+                shared_weights[i] = weights[batch_idx][point_idx][k][c];
+        }
+
+        __syncthreads();
+
+        // PConv -> parallelize across output channels
+        const int total_channels = C_mid * (C_in + C_add);
+
+        #pragma unroll
+        for (int c = tid; c < total_channels; c += blockDim.x) {
+                const int mid_idx = c % C_mid;
+                const int in_idx = c / C_mid;
+                
+                scalar_t sum = 0;
+                #pragma unroll
+                for (int k = 0; k < K; k++) {
+                if (in_idx < C_in) {
+                        sum += shared_input[k * C_in + in_idx] * shared_weights[k * C_mid + mid_idx];
+                } else {
+                        sum += shared_additional[k * C_add + (in_idx - C_in)] * shared_weights[k * C_mid + mid_idx];
                 }
-
-                // Load additional features into shared memory
-                if (C_add > 0) {
-                        for (k = threadIdx.x; k < K * C_add; k += blockDim.x) {
-                                int k_idx = k / C_add;
-                                int c_idx = k % C_add;
-                                shared_additional[k] = additional_features[ii][i][k_idx][c_idx];
-                        }
                 }
+                shared_intermediate[c] = sum;
+        }
 
-                for (int c = threadIdx.x; c < C_mid * (C_in + C_add); c += blockDim.x) {
-                        shared_fused_output[c] = 0.0;
+        __syncthreads();
+
+        // Linear layer -> each thread handles one output channel
+        if (tid < C_out) {
+                scalar_t sum = 0;
+                #pragma unroll
+                for (int c = 0; c < total_channels; c++) {
+                sum += shared_intermediate[c] * linear_weights[tid][c];
                 }
-
-                __syncthreads(); // Sync threads after loading into shared memory
-
-                // PConv
-                for (kk = threadIdx.x % increment; kk < C_in; kk += increment) {
-                        #pragma unroll
-                        for (k = 0; k < K; k++) {
-                                shared_fused_output[jj + kk * C_mid] += shared_input[k * C_in + kk] * weights[ii][i][k][jj];
-                        }
-                }
-
-                if (C_add > 0) {
-                        for (kk = threadIdx.x % increment; kk < C_add; kk += increment) {
-                                #pragma unroll
-                                for (k = 0; k < K; k++) {
-                                        shared_fused_output[jj + (kk + C_in) * C_mid] += shared_additional[k * C_add + kk] * weights[ii][i][k][jj];
-                                }
-                        }
-                }
-
-                __syncthreads(); // Sync threads before applying linear layer
-
-                // Linear
-                for (int c_out = threadIdx.x; c_out < C_out; c_out += blockDim.x) {
-                        scalar_t linear_sum = 0.0;
-                        for (int c_in = 0; c_in < C_mid * (C_in + C_add); c_in++) {
-                                linear_sum += shared_fused_output[c_in] * linear_weights[c_out][c_in];
-                        }
-                        final_output[ii][i][c_out] = linear_sum + linear_bias[c_out];
-                }
-
-                __syncthreads();
-	}
+                final_output[batch_idx][point_idx][tid] = sum + linear_bias[tid];
+        }
 }
 
 template <typename scalar_t>
@@ -414,6 +411,103 @@ __global__ void pconv_cuda_backward_kernel(
 	}
 }
 
+// template <typename scalar_t>
+// __global__ void pconv_linear_cuda_backward_kernel(
+//     const torch::PackedTensorAccessor32<scalar_t, 3, torch::RestrictPtrTraits> __restrict__ grad_output_linear,
+//     const torch::PackedTensorAccessor32<scalar_t, 3, torch::RestrictPtrTraits> __restrict__ pconv_output,
+//     const torch::PackedTensorAccessor32<scalar_t, 3, torch::RestrictPtrTraits> __restrict__ input,
+//     const torch::PackedTensorAccessor32<long, 3, torch::RestrictPtrTraits> __restrict__ neighbor_inds,
+//     const torch::PackedTensorAccessor32<scalar_t, 4, torch::RestrictPtrTraits> __restrict__ weights,
+//     const torch::PackedTensorAccessor32<scalar_t, 4, torch::RestrictPtrTraits> __restrict__ additional_features,
+//     const torch::PackedTensorAccessor32<scalar_t, 2, torch::RestrictPtrTraits> __restrict__ linear_weights,
+//     const torch::PackedTensorAccessor32<scalar_t, 1, torch::RestrictPtrTraits> __restrict__ linear_bias,
+//     torch::PackedTensorAccessor32<scalar_t, 3, torch::RestrictPtrTraits> __restrict__ grad_input,
+//     torch::PackedTensorAccessor32<scalar_t, 4, torch::RestrictPtrTraits> __restrict__ grad_weights,
+//     torch::PackedTensorAccessor32<scalar_t, 4, torch::RestrictPtrTraits> __restrict__ grad_additional,
+//     torch::PackedTensorAccessor32<scalar_t, 2, torch::RestrictPtrTraits> __restrict__ grad_linear_weights,
+//     torch::PackedTensorAccessor32<scalar_t, 1, torch::RestrictPtrTraits> __restrict__ grad_linear_bias)
+// /* 
+//    grad_output: B x N x (C_mid * C_in), the gradient derived from above
+//    input: B x N x C_in tensor, B = batch size, N = number of points, C_in = number of channels, input features
+//    neighbor_inds: B x N x K tensor, K = neighborhood size, indices of the neighborhood of each point
+//    weights: B x N x K x C_mid, C_mid = number of middle channels
+//    additional_features: B x N x K x C_add, additional features that do not need gather
+//    grad_input: same shape as input, gradient of input
+//    grad_weights: same shape as weights, gradient of weights
+
+//    Forward is:
+//     sum_{i} input[b,n][neighbor_inds[i]][j] * weights[b,n,k,i]
+// */
+
+// {
+//         int i, j, k, ii, kk, iter0;
+//         const int B = input.size(0);
+//         const int N = input.size(1);
+//         const int Nout = neighbor_inds.size(1);
+//         const int C_in = input.size(2);
+//         const int K = neighbor_inds.size(2);
+//         const int C_mid = weights.size(3);
+// 	const int C_add = additional_features.size(3);
+//         const int increment = blockDim.x / C_mid;
+//         const int cur_mid = threadIdx.x / increment;
+//         const int C_out = linear_weights.size(0);
+
+//         extern __shared__ unsigned char memory[];
+//         scalar_t* shared_grad_output_pconv = reinterpret_cast<scalar_t*>(memory);
+
+//         if (cur_mid >= C_mid)
+//                 return;
+
+//         // Compute grad_output_pconv from grad_output_linear
+//         for (iter0 = blockIdx.x; iter0 < B * Nout; iter0 += gridDim.x) {
+//                 ii = iter0 / Nout;  // Batch index
+//                 i = iter0 % Nout;   // Point index
+//                 k = threadIdx.x % K;
+
+//                 scalar_t grad_temp = 0.0;
+
+//                 for (kk = 0; kk < C_out; kk++) {
+//                         grad_temp += grad_output_linear[ii][i][kk] * linear_weights[kk][cur_mid];
+//                         atomicAdd(&grad_linear_weights[kk][cur_mid], grad_output_linear[ii][i][kk] * pconv_output[ii][i][cur_mid]);
+//                 }
+
+//                 // grad_output_pconv[ii][i][cur_mid] = grad_temp;
+//                 shared_grad_output_pconv[threadIdx.x] = grad_temp;
+//         }
+
+//         __syncthreads();
+
+//         // Supposedly blockIdx.x should go up to B * N
+//         for (iter0 = blockIdx.x; iter0 < B * Nout; iter0 += gridDim.x) {
+//                 // ii is the index on the batch dimension
+//                 ii = iter0 / Nout;
+//                 // i is the index on the point dimension
+//                 i = iter0 % Nout;
+//                 k = threadIdx.x % K;
+//                 scalar_t weight_grad_temp = 0.0;
+//                 scalar_t cur_compute;
+
+//                 #pragma unroll
+//                 for (kk = 0; kk < C_in; kk++) {
+//                         long cur_channel = cur_mid * (C_in + C_add) + kk;
+//                         cur_compute = shared_grad_output_pconv[threadIdx.x] * weights[ii][i][k][cur_mid];
+//                         weight_grad_temp += shared_grad_output_pconv[threadIdx.x] * input[ii][neighbor_inds[ii][i][k]][kk];
+//                 // It would be quite expensive to store this in shared memory so use this naive approach for now, using atomicAdd to avoid racing conditions
+//                         atomicAdd(&grad_input[ii][neighbor_inds[ii][i][k]][kk], cur_compute);
+//                 }
+
+// 		for (kk = 0; kk < C_add; kk++) {
+// 			long cur_channel = cur_mid * (C_in + C_add) + kk + C_in;
+// 			cur_compute = shared_grad_output_pconv[threadIdx.x] * weights[ii][i][k][cur_mid];
+// 			weight_grad_temp += shared_grad_output_pconv[threadIdx.x] * additional_features[ii][i][k][kk];
+// 			grad_additional[ii][i][k][kk] = cur_compute;
+// 		}
+//                 grad_weights[ii][i][k][cur_mid] = weight_grad_temp;
+
+//                 __syncthreads();
+// 	}
+// }
+
 torch::Tensor pcf_cuda_forward(
     torch::Tensor input,
     torch::Tensor neighbor_inds,
@@ -517,32 +611,40 @@ torch::Tensor pconv_linear_cuda_forward(
 )
 {
         const int B = input.size(0);
-        const int N = input.size(1);
         const int Nout = neighbor_inds.size(1);
         const int C_in = input.size(2);
-	const int C_add = additional_features.size(3);
-        const int C_mid =  weights.size(3);
-        const int C_out = linear_weights.size(0);
-        const int numBlocks = B * Nout;
-        const int numThreads = C_mid * C_in > 256 ? 256 : C_mid * C_in;
-
-        // Calculate shared memory size for input, additional features and intermediates
         const int K = neighbor_inds.size(2);
-        // const int shared_mem_size = (K * (C_in + C_add)) * sizeof(float);
-        const int shared_mem_size = (K * C_in + K * C_add + C_mid * (C_in + C_add)) * sizeof(float);
+        const int C_mid = weights.size(3);
+        const int C_add = additional_features.size(3);
+        const int C_out = linear_weights.size(0);
 
-        auto output = torch::zeros({B, N, C_out}, input.type());
+        auto output = torch::zeros({B, Nout, C_out}, 
+                                input.options());
 
-        AT_DISPATCH_FLOATING_TYPES(output.type(), "pconv_linear_cuda_forward_kernel", ([&] {
-        pconv_linear_cuda_forward_kernel<scalar_t><<<numBlocks, numThreads, shared_mem_size>>>(
+        // Optimal thread count
+        const int total_work = std::max({K * C_in, K * C_add, K * C_mid, C_out});
+        const int thread_count = std::min(256, nextPowerOf2(total_work));
+
+        dim3 grid(B, Nout);
+
+        const int shared_mem_size = (
+                (K * C_in) +                    // shared_input
+                (K * C_add) +                   // shared_additional  
+                (K * C_mid) +                   // shared_weights
+                (C_mid * (C_in + C_add))        // shared_intermediate
+        ) * sizeof(float);
+
+        AT_DISPATCH_FLOATING_TYPES(input.type(), "pconv_linear_cuda_forward_kernel", ([&] {
+                pconv_linear_cuda_forward_kernel<scalar_t><<<grid, thread_count, shared_mem_size>>>(
                 input.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>(),
                 neighbor_inds.packed_accessor32<long,3,torch::RestrictPtrTraits>(),
                 weights.packed_accessor32<scalar_t,4,torch::RestrictPtrTraits>(),
-		additional_features.packed_accessor32<scalar_t,4,torch::RestrictPtrTraits>(),
+                additional_features.packed_accessor32<scalar_t,4,torch::RestrictPtrTraits>(),
                 linear_weights.packed_accessor32<scalar_t,2,torch::RestrictPtrTraits>(),
                 linear_bias.packed_accessor32<scalar_t,1,torch::RestrictPtrTraits>(),
                 output.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>());
         }));
+
         return output;
 }
 
@@ -577,6 +679,53 @@ std::vector<torch::Tensor> pconv_cuda_backward(
         grad_weights.packed_accessor32<scalar_t,4,torch::RestrictPtrTraits>(),
 	grad_additional.packed_accessor32<scalar_t,4,torch::RestrictPtrTraits>());
         }));
-    return {grad_input,grad_weights,grad_additional};
+    return {grad_input, grad_weights, grad_additional};
 }
 
+// std::vector<torch::Tensor> pconv_linear_cuda_backward(
+//     torch::Tensor grad_output,           // B x N x (C_mid * C_out)
+//     torch::Tensor input,                 // B x N x C_in
+//     torch::Tensor neighbor_inds,         // B x N x K
+//     torch::Tensor weights,               // B x N x K x C_mid
+//     torch::Tensor additional_features,   // B x N x K x C_add
+//     torch::Tensor linear_weights,        // C_out x C_mid
+//     torch::Tensor linear_bias,
+//     torch::Tensor pconv_output)          // B x N x C_mid (from forward pass)
+// {
+//     const int B = input.size(0);
+//     const int N = input.size(1);
+//     const int Nout = neighbor_inds.size(1);
+//     const int C_in = input.size(2);
+//     const int C_mid = weights.size(3);
+//     const int C_out = linear_weights.size(0);
+//     const int K = neighbor_inds.size(2);
+
+//     const int numBlocks = B * Nout;             // Blocks for each batch-point combination
+//     const int numThreads = C_mid * K;           // Threads for each mid-channel and neighbor
+//     const size_t shared_mem_size = sizeof(float) * C_mid; // Shared memory size per block
+
+//     auto grad_input = torch::zeros_like(input);
+//     auto grad_weights = torch::zeros_like(weights);
+//     auto grad_additional = torch::zeros_like(additional_features);
+//     auto grad_linear_weights = torch::zeros_like(linear_weights);
+//     auto grad_linear_bias = torch::zeros_like(linear_bias);
+
+//     AT_DISPATCH_FLOATING_TYPES(grad_output.type(), "pconv_linear_cuda_backward_kernel", ([&] {
+//         pconv_linear_cuda_backward_kernel<scalar_t><<<numBlocks, numThreads, shared_mem_size>>>(
+//             grad_output.packed_accessor32<scalar_t, 3, torch::RestrictPtrTraits>(),
+//             pconv_output.packed_accessor32<scalar_t, 3, torch::RestrictPtrTraits>(),
+//             input.packed_accessor32<scalar_t, 3, torch::RestrictPtrTraits>(),
+//             neighbor_inds.packed_accessor32<long, 3, torch::RestrictPtrTraits>(),
+//             weights.packed_accessor32<scalar_t, 4, torch::RestrictPtrTraits>(),
+//             additional_features.packed_accessor32<scalar_t, 4, torch::RestrictPtrTraits>(),
+//             linear_weights.packed_accessor32<scalar_t, 2, torch::RestrictPtrTraits>(),
+//             linear_bias.packed_accessor32<scalar_t, 1, torch::RestrictPtrTraits>(),
+//             grad_input.packed_accessor32<scalar_t, 3, torch::RestrictPtrTraits>(),
+//             grad_weights.packed_accessor32<scalar_t, 4, torch::RestrictPtrTraits>(),
+//             grad_additional.packed_accessor32<scalar_t, 4, torch::RestrictPtrTraits>(),
+//             grad_linear_weights.packed_accessor32<scalar_t, 2, torch::RestrictPtrTraits>(),
+//             grad_linear_bias.packed_accessor32<scalar_t, 1, torch::RestrictPtrTraits>());
+//     }));
+
+//     return {grad_input, grad_weights, grad_additional, grad_linear_weights, grad_linear_bias};
+// }

--- a/cpp_wrappers/cpp_pcf_kernel/pcf_cuda_kernel.cu
+++ b/cpp_wrappers/cpp_pcf_kernel/pcf_cuda_kernel.cu
@@ -39,47 +39,47 @@ __global__ void convert_to_half(
 }
     
 
+__global__ void count_neighbors_kernel(
+        const torch::PackedTensorAccessor32<int32_t, 3, torch::RestrictPtrTraits> neighbor_inds,
+        torch::PackedTensorAccessor32<int32_t, 1, torch::RestrictPtrTraits> counts,
+        const int total_points,
+        const int start_point,
+        const int batch_idx
+) {
+        const int local_point_idx = blockIdx.y;
+        const int point_idx = start_point + local_point_idx;
+        const int tid = threadIdx.x;
+        const int K = neighbor_inds.size(2);
+
+        for (int k = tid; k < K; k += blockDim.x) {
+                const int32_t neighbor = neighbor_inds[batch_idx][point_idx][k];
+                if (neighbor >= 0 && neighbor < total_points) {
+                        atomicAdd(&counts[neighbor], 1);
+                }
+        }
+}
+    
+
 __global__ void compute_inv_idx_kernel(
-        torch::PackedTensorAccessor32<int,1,torch::RestrictPtrTraits> counts,
-        torch::PackedTensorAccessor32<long,2,torch::RestrictPtrTraits> inv_idx,
+        torch::PackedTensorAccessor32<int32_t, 1, torch::RestrictPtrTraits> counts,
+        torch::PackedTensorAccessor32<int32_t, 2, torch::RestrictPtrTraits> inv_idx,
         const int total_points,
         const int batch_idx
 ) {
-        long sum = 0;
+        int32_t sum = 0;
         inv_idx[batch_idx][0] = 0;
         for (int i = 0; i < total_points; i++) {
                 sum += counts[i];
                 inv_idx[batch_idx][i + 1] = sum;
         }
 }
-    
-
-__global__ void count_neighbors_kernel(
-        const torch::PackedTensorAccessor32<long,3,torch::RestrictPtrTraits> neighbor_inds,
-        torch::PackedTensorAccessor32<int,1,torch::RestrictPtrTraits> counts,
-        const int total_points,
-        const int start_point,
-        const int batch_idx
-) {
-        const int local_point_idx = blockIdx.y;
-        const int point_idx = start_point + local_point_idx;
-        const int tid = threadIdx.x;
-        const int K = neighbor_inds.size(2);
-
-        for (int k = tid; k < K; k += blockDim.x) {
-                const long neighbor = neighbor_inds[batch_idx][point_idx][k];
-                if (neighbor >= 0 && neighbor < total_points) {
-                        atomicAdd(&counts[neighbor], 1);
-                }
-        }
-}
 
 __global__ void fill_inverse_kernel(
-        const torch::PackedTensorAccessor32<long,3,torch::RestrictPtrTraits> neighbor_inds,
-        torch::PackedTensorAccessor32<long,2,torch::RestrictPtrTraits> inv_neighbors,
-        torch::PackedTensorAccessor32<long,2,torch::RestrictPtrTraits> inv_k,
-        torch::PackedTensorAccessor32<int,1,torch::RestrictPtrTraits> running_counts,
-        torch::PackedTensorAccessor32<long,2,torch::RestrictPtrTraits> inv_idx,
+        const torch::PackedTensorAccessor32<int32_t, 3, torch::RestrictPtrTraits> neighbor_inds,
+        torch::PackedTensorAccessor32<int32_t, 2, torch::RestrictPtrTraits> inv_neighbors,
+        torch::PackedTensorAccessor32<int32_t, 2, torch::RestrictPtrTraits> inv_k,
+        torch::PackedTensorAccessor32<int32_t, 1, torch::RestrictPtrTraits> running_counts,
+        torch::PackedTensorAccessor32<int32_t, 2, torch::RestrictPtrTraits> inv_idx,
         const int total_points,
         const int start_point,
         const int batch_idx
@@ -90,10 +90,10 @@ __global__ void fill_inverse_kernel(
         const int K = neighbor_inds.size(2);
 
         for (int k = tid; k < K; k += blockDim.x) {
-                const long neighbor = neighbor_inds[batch_idx][point_idx][k];
+                const int32_t neighbor = neighbor_inds[batch_idx][point_idx][k];
                 if (neighbor >= 0 && neighbor < total_points) {
-                        const int pos = atomicAdd(&running_counts[neighbor], 1);
-                        const long idx = inv_idx[batch_idx][neighbor] + pos;
+                        const int32_t pos = atomicAdd(&running_counts[neighbor], 1);
+                        const int32_t idx = inv_idx[batch_idx][neighbor] + pos;
                         inv_neighbors[batch_idx][idx] = point_idx;
                         inv_k[batch_idx][idx] = k;
                 }
@@ -813,67 +813,71 @@ std::vector<torch::Tensor> pconv_linear_cuda_backward(
 
 std::vector<torch::Tensor> knn_inverse_cuda_forward(
         torch::Tensor neighbor_inds,
-        const int total_points) 
-{
-    const int B = neighbor_inds.size(0);
-    const int N = neighbor_inds.size(1);
-    const int K = neighbor_inds.size(2);
+        const int total_points
+) {
+        const int B = neighbor_inds.size(0);
+        const int N = neighbor_inds.size(1);
+        const int K = neighbor_inds.size(2);
 
-    auto inv_neighbors = torch::zeros({B, N * K}, neighbor_inds.options());
-    auto inv_k = torch::zeros({B, N * K}, neighbor_inds.options());
-    auto inv_idx = torch::zeros({B, total_points + 1}, neighbor_inds.options());
+        auto neighbor_inds_int32 = neighbor_inds.to(torch::kInt32);
 
-    const int threads_per_block = std::min(512, K);
-    const int points_per_grid = 65535;
-    const int num_y_grids = (N + points_per_grid - 1) / points_per_grid;
+        auto options = torch::TensorOptions().dtype(torch::kInt32).device(neighbor_inds.device());
+        auto inv_neighbors = torch::zeros({B, N * K}, options);
+        auto inv_k = torch::zeros({B, N * K}, options);
+        auto inv_idx = torch::zeros({B, total_points + 1}, options);
 
-    for (int b = 0; b < B; b++) {
-        auto counts = torch::zeros({total_points}, neighbor_inds.options().dtype(torch::kInt32));
+        const int threads_per_block = K;
+        const int points_per_grid = 65535;
+        const int num_y_grids = (N + points_per_grid - 1) / points_per_grid;
 
-        for (int grid_idx = 0; grid_idx < num_y_grids; grid_idx++) {
-            const int start_point = grid_idx * points_per_grid;
-            const int points_this_grid = std::min(points_per_grid, N - start_point);
-            const dim3 block(threads_per_block);
-            const dim3 grid(1, points_this_grid);
+        for (int b = 0; b < B; b++) {
+                auto counts = torch::zeros({total_points}, options.dtype(torch::kInt32));
 
-            count_neighbors_kernel<<<grid, block>>>(
-                neighbor_inds.packed_accessor32<long,3,torch::RestrictPtrTraits>(),
-                counts.packed_accessor32<int,1,torch::RestrictPtrTraits>(),
-                total_points,
-                start_point,
-                b
-            );
+                // Count neighbors
+                for (int grid_idx = 0; grid_idx < num_y_grids; grid_idx++) {
+                        const int start_point = grid_idx * points_per_grid;
+                        const int points_this_grid = std::min(points_per_grid, N - start_point);
+                        const dim3 block(threads_per_block);
+                        const dim3 grid(1, points_this_grid);
+
+                        count_neighbors_kernel<<<grid, block>>>(
+                                neighbor_inds_int32.packed_accessor32<int32_t, 3, torch::RestrictPtrTraits>(),
+                                counts.packed_accessor32<int32_t, 1, torch::RestrictPtrTraits>(),
+                                total_points,
+                                start_point,
+                                b
+                        );
+                }
+
+                // Compute inv_idx
+                compute_inv_idx_kernel<<<1, 1>>>(
+                        counts.packed_accessor32<int32_t, 1, torch::RestrictPtrTraits>(),
+                        inv_idx.packed_accessor32<int32_t, 2, torch::RestrictPtrTraits>(),
+                        total_points,
+                        b
+                );
+
+                counts.zero_();
+
+                // Fill inverse mapping
+                for (int grid_idx = 0; grid_idx < num_y_grids; grid_idx++) {
+                        const int start_point = grid_idx * points_per_grid;
+                        const int points_this_grid = std::min(points_per_grid, N - start_point);
+                        const dim3 block(threads_per_block);
+                        const dim3 grid(1, points_this_grid);
+
+                        fill_inverse_kernel<<<grid, block>>>(
+                                neighbor_inds_int32.packed_accessor32<int32_t, 3, torch::RestrictPtrTraits>(),
+                                inv_neighbors.packed_accessor32<int32_t, 2, torch::RestrictPtrTraits>(),
+                                inv_k.packed_accessor32<int32_t, 2, torch::RestrictPtrTraits>(),
+                                counts.packed_accessor32<int32_t, 1, torch::RestrictPtrTraits>(),
+                                inv_idx.packed_accessor32<int32_t, 2, torch::RestrictPtrTraits>(),
+                                total_points,
+                                start_point,
+                                b
+                        );
+                }
         }
 
-        compute_inv_idx_kernel<<<1, 1>>>(
-            counts.packed_accessor32<int,1,torch::RestrictPtrTraits>(),
-            inv_idx.packed_accessor32<long,2,torch::RestrictPtrTraits>(),
-            total_points,
-            b
-        );
-
-        // Reset counts to zero for reuse
-        counts.zero_();
-
-        // Fill inverse mapping
-        for (int grid_idx = 0; grid_idx < num_y_grids; grid_idx++) {
-            const int start_point = grid_idx * points_per_grid;
-            const int points_this_grid = std::min(points_per_grid, N - start_point);
-            const dim3 block(threads_per_block);
-            const dim3 grid(1, points_this_grid);
-
-            fill_inverse_kernel<<<grid, block>>>(
-                neighbor_inds.packed_accessor32<long,3,torch::RestrictPtrTraits>(),
-                inv_neighbors.packed_accessor32<long,2,torch::RestrictPtrTraits>(),
-                inv_k.packed_accessor32<long,2,torch::RestrictPtrTraits>(),
-                counts.packed_accessor32<int,1,torch::RestrictPtrTraits>(),
-                inv_idx.packed_accessor32<long,2,torch::RestrictPtrTraits>(),
-                total_points,
-                start_point,
-                b
-            );
-        }
-    }
-
-    return {inv_neighbors, inv_k, inv_idx};
+        return {inv_neighbors, inv_k, inv_idx};
 }

--- a/cpp_wrappers/cpp_pcf_kernel/pcf_cuda_kernel.cu
+++ b/cpp_wrappers/cpp_pcf_kernel/pcf_cuda_kernel.cu
@@ -35,66 +35,68 @@ __global__ void convert_to_half(
 }
 
 
-
 // Simple counting to get the number of neighbors for each point
 __global__ void count_neighbors_kernel(
-    const torch::PackedTensorAccessor32<int,3,torch::RestrictPtrTraits> neighbor_inds,
-    torch::PackedTensorAccessor32<int,2,torch::RestrictPtrTraits> counts,
-    const int total_points
+        const torch::PackedTensorAccessor32<int,3,torch::RestrictPtrTraits> neighbor_inds,
+        torch::PackedTensorAccessor32<int,1,torch::RestrictPtrTraits> counts,
+        const int total_points,
+        const int start_point,
+        const int batch_idx
 ) {
-    const int batch_idx = blockIdx.x;
-    const int point_idx = blockIdx.y;
-    const int k_idx = threadIdx.x;
+        const int local_point_idx = blockIdx.y;
+        const int point_idx = start_point + local_point_idx;
+        const int tid = threadIdx.x;
+        const int K = neighbor_inds.size(2);
 
-    const int K = neighbor_inds.size(2);
-    if (k_idx >= K) return;
-
-    const int neighbor = neighbor_inds[batch_idx][point_idx][k_idx];
-    if (neighbor >= 0 && neighbor < total_points) {
-        atomicAdd(&counts[batch_idx][neighbor], 1);
-    }
+        // Process K neighbors in strided fashion
+        for (int k = tid; k < K; k += blockDim.x) {
+                const int neighbor = neighbor_inds[batch_idx][point_idx][k];
+                if (neighbor >= 0 && neighbor < total_points) {
+                        atomicAdd(&counts[neighbor], 1);
+                }
+        }
 }
 
 // Compute inv_idx for counts
 __global__ void compute_inv_idx_kernel(
-    torch::PackedTensorAccessor32<int,2,torch::RestrictPtrTraits> counts,
-    torch::PackedTensorAccessor32<int,2,torch::RestrictPtrTraits> inv_idx,
-    const int total_points
+        torch::PackedTensorAccessor32<int,1,torch::RestrictPtrTraits> counts,
+        torch::PackedTensorAccessor32<int,2,torch::RestrictPtrTraits> inv_idx,
+        const int total_points,
+        const int batch_idx
 ) {
-    const int batch_idx = blockIdx.x;
-
-    if (threadIdx.x == 0) {
         inv_idx[batch_idx][0] = 0;
         for (int i = 0; i < total_points; i++) {
-            inv_idx[batch_idx][i + 1] = inv_idx[batch_idx][i] + counts[batch_idx][i];
+                inv_idx[batch_idx][i + 1] = inv_idx[batch_idx][i] + counts[i];
         }
-    }
 }
 
 // Fill inverse neighbors and k indices
 __global__ void fill_inverse_kernel(
-    const torch::PackedTensorAccessor32<int,3,torch::RestrictPtrTraits> neighbor_inds,
-    torch::PackedTensorAccessor32<int,2,torch::RestrictPtrTraits> inv_neighbors,
-    torch::PackedTensorAccessor32<int,2,torch::RestrictPtrTraits> inv_k,
-    torch::PackedTensorAccessor32<int,2,torch::RestrictPtrTraits> running_counts,
-    torch::PackedTensorAccessor32<int,2,torch::RestrictPtrTraits> inv_idx,
-    const int total_points
+        const torch::PackedTensorAccessor32<int,3,torch::RestrictPtrTraits> neighbor_inds,
+        torch::PackedTensorAccessor32<int,2,torch::RestrictPtrTraits> inv_neighbors,
+        torch::PackedTensorAccessor32<int,2,torch::RestrictPtrTraits> inv_k,
+        torch::PackedTensorAccessor32<int,1,torch::RestrictPtrTraits> running_counts,
+        torch::PackedTensorAccessor32<int,2,torch::RestrictPtrTraits> inv_idx,
+        const int total_points,
+        const int start_point,
+        const int batch_idx
 ) {
-    const int batch_idx = blockIdx.x;
-    const int point_idx = blockIdx.y;
-    const int k_idx = threadIdx.x;
+        const int local_point_idx = blockIdx.y;
+        const int point_idx = start_point + local_point_idx;
+        const int tid = threadIdx.x;
+        const int K = neighbor_inds.size(2);
 
-    const int K = neighbor_inds.size(2);
-    if (k_idx >= K) return;
+        // Process K neighbors in strided fashion
+        for (int k = tid; k < K; k += blockDim.x) {
+                const int neighbor = neighbor_inds[batch_idx][point_idx][k];
+                if (neighbor >= 0 && neighbor < total_points) {
+                        const int pos = atomicAdd(&running_counts[neighbor], 1);
+                        const int idx = inv_idx[batch_idx][neighbor] + pos;
 
-    const int neighbor = neighbor_inds[batch_idx][point_idx][k_idx];
-    if (neighbor >= 0 && neighbor < total_points) {
-        const int pos = atomicAdd(&running_counts[batch_idx][neighbor], 1);
-        const int idx = inv_idx[batch_idx][neighbor] + pos;
-
-        inv_neighbors[batch_idx][idx] = point_idx;
-        inv_k[batch_idx][idx] = k_idx;
-    }
+                        inv_neighbors[batch_idx][idx] = point_idx;
+                        inv_k[batch_idx][idx] = k;
+                }
+        }
 }
 
 
@@ -809,50 +811,78 @@ std::vector<torch::Tensor> pconv_linear_cuda_backward(
 
 
 std::vector<torch::Tensor> knn_inverse_cuda_forward(
-    torch::Tensor neighbor_inds,
-    const int total_points) 
+        torch::Tensor neighbor_inds,
+        const int total_points) 
 {
-    const int B = neighbor_inds.size(0);
-    const int N = neighbor_inds.size(1);
-    const int K = neighbor_inds.size(2);
+        const int B = neighbor_inds.size(0);
+        const int N = neighbor_inds.size(1);
+        const int K = neighbor_inds.size(2);
 
-    // Convert input to int if its not already
-    auto neighbor_inds_int = neighbor_inds.to(torch::kInt32);
+        // Convert input to int if its not already
+        auto neighbor_inds_int = neighbor_inds.to(torch::kInt32);
 
-    auto counts = torch::zeros({B, total_points}, neighbor_inds_int.options());
-    auto inv_idx = torch::zeros({B, total_points + 1}, neighbor_inds_int.options());
-    auto running_counts = torch::zeros({B, total_points}, neighbor_inds_int.options());
-    auto inv_neighbors = torch::zeros({B, N * K}, neighbor_inds_int.options());
-    auto inv_k = torch::zeros({B, N * K}, neighbor_inds_int.options());
+        auto inv_neighbors = torch::zeros({B, N * K}, neighbor_inds_int.options());
+        auto inv_k = torch::zeros({B, N * K}, neighbor_inds_int.options());
+        auto inv_idx = torch::zeros({B, total_points + 1}, neighbor_inds_int.options());
 
-    const dim3 block(256);
-    const dim3 grid(B, N);
+        const int threads_per_block = 512;
+        const int points_per_grid = 65535;
+        const int num_y_grids = (N + points_per_grid - 1) / points_per_grid;
 
-    // Count neighbors
-    count_neighbors_kernel<<<grid, block>>>(
-        neighbor_inds_int.packed_accessor32<int,3,torch::RestrictPtrTraits>(),
-        counts.packed_accessor32<int,2,torch::RestrictPtrTraits>(),
-        total_points
-    );
+        // Process each batch separately - we do this to save memory for large point clouds
+        for (int b = 0; b < B; b++) {
+                auto counts = torch::zeros({total_points}, neighbor_inds_int.options());
+                auto running_counts = torch::zeros({total_points}, neighbor_inds_int.options());
 
-    // Compute inv_idx
-    compute_inv_idx_kernel<<<B, 1>>>(
-        counts.packed_accessor32<int,2,torch::RestrictPtrTraits>(),
-        inv_idx.packed_accessor32<int,2,torch::RestrictPtrTraits>(),
-        total_points
-    );
+                // Count neighbors for this batch
+                for (int grid_idx = 0; grid_idx < num_y_grids; grid_idx++) {
+                        const int start_point = grid_idx * points_per_grid;
+                        const int points_this_grid = std::min(points_per_grid, N - start_point);
 
-    // Fill inverse neighbors and k indices
-    fill_inverse_kernel<<<grid, block>>>(
-        neighbor_inds_int.packed_accessor32<int,3,torch::RestrictPtrTraits>(),
-        inv_neighbors.packed_accessor32<int,2,torch::RestrictPtrTraits>(),
-        inv_k.packed_accessor32<int,2,torch::RestrictPtrTraits>(),
-        running_counts.packed_accessor32<int,2,torch::RestrictPtrTraits>(),
-        inv_idx.packed_accessor32<int,2,torch::RestrictPtrTraits>(),
-        total_points
-    );
+                        const dim3 block(threads_per_block);
+                        const dim3 grid(1, points_this_grid);  // only 1 batch
 
-    return {inv_neighbors.to(neighbor_inds.dtype()), 
-            inv_k.to(neighbor_inds.dtype()), 
-            inv_idx.to(neighbor_inds.dtype())};
+                        count_neighbors_kernel<<<grid, block>>>(
+                                neighbor_inds_int.packed_accessor32<int,3,torch::RestrictPtrTraits>(),
+                                counts.packed_accessor32<int,1,torch::RestrictPtrTraits>(),
+                                total_points,
+                                start_point,
+                                b
+                        );
+                }
+
+                // Get inv_idx for this batch
+                compute_inv_idx_kernel<<<1, 1>>>(
+                        counts.packed_accessor32<int,1,torch::RestrictPtrTraits>(),
+                        inv_idx.packed_accessor32<int,2,torch::RestrictPtrTraits>(),
+                        total_points,
+                        b
+                );
+
+                // Fill inverse mapping for this batch
+                for (int grid_idx = 0; grid_idx < num_y_grids; grid_idx++) {
+                        const int start_point = grid_idx * points_per_grid;
+                        const int points_this_grid = std::min(points_per_grid, N - start_point);
+
+                        const dim3 block(threads_per_block);
+                        const dim3 grid(1, points_this_grid);  // only 1 batch
+
+                        fill_inverse_kernel<<<grid, block>>>(
+                                neighbor_inds_int.packed_accessor32<int,3,torch::RestrictPtrTraits>(),
+                                inv_neighbors.packed_accessor32<int,2,torch::RestrictPtrTraits>(),
+                                inv_k.packed_accessor32<int,2,torch::RestrictPtrTraits>(),
+                                running_counts.packed_accessor32<int,1,torch::RestrictPtrTraits>(),
+                                inv_idx.packed_accessor32<int,2,torch::RestrictPtrTraits>(),
+                                total_points,
+                                start_point,
+                                b
+                        );
+                }
+
+                // counts and running_counts are automatically freed here
+        }
+
+        return {inv_neighbors.to(neighbor_inds.dtype()), 
+                inv_k.to(neighbor_inds.dtype()), 
+                inv_idx.to(neighbor_inds.dtype())};
 }

--- a/cpp_wrappers/cpp_pcf_kernel/pcf_cuda_kernel.cu
+++ b/cpp_wrappers/cpp_pcf_kernel/pcf_cuda_kernel.cu
@@ -1283,7 +1283,7 @@ std::vector<torch::Tensor> pconv_linear_cutlass_forward(
                                 float, LayoutC,
                                 float,
                                 cutlass::arch::OpClassSimt,
-                                cutlass::arch::Sm70,
+                                cutlass::arch::Sm90,
                                 cutlass::gemm::GemmShape<64, 64, 8>,
                                 cutlass::gemm::GemmShape<32, 32, 8>,
                                 cutlass::gemm::GemmShape<1, 1, 1>
@@ -1346,7 +1346,7 @@ std::vector<torch::Tensor> pconv_linear_cutlass_forward(
                                 float, cutlass::layout::RowMajor,
                                 float,
                                 cutlass::arch::OpClassSimt,
-                                cutlass::arch::Sm70,
+                                cutlass::arch::Sm90,
                                 cutlass::gemm::GemmShape<64, 64, 8>,
                                 cutlass::gemm::GemmShape<32, 32, 8>,
                                 cutlass::gemm::GemmShape<1, 1, 1>
@@ -1416,7 +1416,7 @@ std::vector<torch::Tensor> pconv_linear_cutlass_forward(
                         float, LayoutC,
                         float,
                         cutlass::arch::OpClassSimt,
-                        cutlass::arch::Sm70,
+                        cutlass::arch::Sm90,
                         cutlass::gemm::GemmShape<64, 64, 8>,
                         cutlass::gemm::GemmShape<32, 32, 8>,
                         cutlass::gemm::GemmShape<1, 1, 1>
@@ -1476,7 +1476,7 @@ std::vector<torch::Tensor> pconv_linear_cutlass_forward(
                         float, cutlass::layout::RowMajor,
                         float,
                         cutlass::arch::OpClassSimt,
-                        cutlass::arch::Sm70,
+                        cutlass::arch::Sm90,
                         cutlass::gemm::GemmShape<64, 64, 8>,
                         cutlass::gemm::GemmShape<32, 32, 8>,
                         cutlass::gemm::GemmShape<1, 1, 1>

--- a/cpp_wrappers/cpp_pcf_kernel/pcf_cuda_kernel.cu
+++ b/cpp_wrappers/cpp_pcf_kernel/pcf_cuda_kernel.cu
@@ -1269,7 +1269,10 @@ std::vector<torch::Tensor> pconv_linear_cutlass_forward(
                                                                 float, Layout,          // C & D
                                                                 float,                  // Accumulator
                                                                 cutlass::arch::OpClassSimt,
-                                                                cutlass::arch::Sm70
+                                                                cutlass::arch::Sm70,
+                                                                cutlass::gemm::GemmShape<64, 64, 8>,   // Threadblock tile size
+                                                                cutlass::gemm::GemmShape<32, 32, 8>,   // Warp tile size
+                                                                cutlass::gemm::GemmShape<1, 1, 1>      // Instruction tile size
                                                         >;
 
         Gemm gemm_op;
@@ -1339,7 +1342,10 @@ std::vector<torch::Tensor> pconv_linear_cutlass_forward(
                                                                 float, Layout,     // shape [B*Nout, C_out]
                                                                 float,             // Acc
                                                                 cutlass::arch::OpClassSimt,
-                                                                cutlass::arch::Sm70
+                                                                cutlass::arch::Sm70,
+                                                                cutlass::gemm::GemmShape<64, 64, 8>,
+                                                                cutlass::gemm::GemmShape<32, 32, 8>,
+                                                                cutlass::gemm::GemmShape<1, 1, 1>
                                                         >;
 
         GemmLinear gemm_linear;

--- a/cpp_wrappers/cpp_pcf_kernel/pcf_cuda_kernel.cu
+++ b/cpp_wrappers/cpp_pcf_kernel/pcf_cuda_kernel.cu
@@ -35,6 +35,69 @@ __global__ void convert_to_half(
 }
 
 
+
+// Simple counting to get the number of neighbors for each point
+__global__ void count_neighbors_kernel(
+    const torch::PackedTensorAccessor32<int,3,torch::RestrictPtrTraits> neighbor_inds,
+    torch::PackedTensorAccessor32<int,2,torch::RestrictPtrTraits> counts,
+    const int total_points
+) {
+    const int batch_idx = blockIdx.x;
+    const int point_idx = blockIdx.y;
+    const int k_idx = threadIdx.x;
+
+    const int K = neighbor_inds.size(2);
+    if (k_idx >= K) return;
+
+    const int neighbor = neighbor_inds[batch_idx][point_idx][k_idx];
+    if (neighbor >= 0 && neighbor < total_points) {
+        atomicAdd(&counts[batch_idx][neighbor], 1);
+    }
+}
+
+// Compute inv_idx for counts
+__global__ void compute_inv_idx_kernel(
+    torch::PackedTensorAccessor32<int,2,torch::RestrictPtrTraits> counts,
+    torch::PackedTensorAccessor32<int,2,torch::RestrictPtrTraits> inv_idx,
+    const int total_points
+) {
+    const int batch_idx = blockIdx.x;
+
+    if (threadIdx.x == 0) {
+        inv_idx[batch_idx][0] = 0;
+        for (int i = 0; i < total_points; i++) {
+            inv_idx[batch_idx][i + 1] = inv_idx[batch_idx][i] + counts[batch_idx][i];
+        }
+    }
+}
+
+// Fill inverse neighbors and k indices
+__global__ void fill_inverse_kernel(
+    const torch::PackedTensorAccessor32<int,3,torch::RestrictPtrTraits> neighbor_inds,
+    torch::PackedTensorAccessor32<int,2,torch::RestrictPtrTraits> inv_neighbors,
+    torch::PackedTensorAccessor32<int,2,torch::RestrictPtrTraits> inv_k,
+    torch::PackedTensorAccessor32<int,2,torch::RestrictPtrTraits> running_counts,
+    torch::PackedTensorAccessor32<int,2,torch::RestrictPtrTraits> inv_idx,
+    const int total_points
+) {
+    const int batch_idx = blockIdx.x;
+    const int point_idx = blockIdx.y;
+    const int k_idx = threadIdx.x;
+
+    const int K = neighbor_inds.size(2);
+    if (k_idx >= K) return;
+
+    const int neighbor = neighbor_inds[batch_idx][point_idx][k_idx];
+    if (neighbor >= 0 && neighbor < total_points) {
+        const int pos = atomicAdd(&running_counts[batch_idx][neighbor], 1);
+        const int idx = inv_idx[batch_idx][neighbor] + pos;
+
+        inv_neighbors[batch_idx][idx] = point_idx;
+        inv_k[batch_idx][idx] = k_idx;
+    }
+}
+
+
 // First goal is to get forward to work to speed up the inference
 // Second goal is to get backward to work to save GPU memory so that we can deal with 2cm better and have larger batch sizes
 
@@ -742,4 +805,54 @@ std::vector<torch::Tensor> pconv_linear_cuda_backward(
         }));
 
         return {grad_input, grad_weights, grad_additional, grad_linear_weights, grad_linear_bias};
+}
+
+
+std::vector<torch::Tensor> knn_inverse_cuda_forward(
+    torch::Tensor neighbor_inds,
+    const int total_points) 
+{
+    const int B = neighbor_inds.size(0);
+    const int N = neighbor_inds.size(1);
+    const int K = neighbor_inds.size(2);
+
+    // Convert input to int if its not already
+    auto neighbor_inds_int = neighbor_inds.to(torch::kInt32);
+
+    auto counts = torch::zeros({B, total_points}, neighbor_inds_int.options());
+    auto inv_idx = torch::zeros({B, total_points + 1}, neighbor_inds_int.options());
+    auto running_counts = torch::zeros({B, total_points}, neighbor_inds_int.options());
+    auto inv_neighbors = torch::zeros({B, N * K}, neighbor_inds_int.options());
+    auto inv_k = torch::zeros({B, N * K}, neighbor_inds_int.options());
+
+    const dim3 block(256);
+    const dim3 grid(B, N);
+
+    // Count neighbors
+    count_neighbors_kernel<<<grid, block>>>(
+        neighbor_inds_int.packed_accessor32<int,3,torch::RestrictPtrTraits>(),
+        counts.packed_accessor32<int,2,torch::RestrictPtrTraits>(),
+        total_points
+    );
+
+    // Compute inv_idx
+    compute_inv_idx_kernel<<<B, 1>>>(
+        counts.packed_accessor32<int,2,torch::RestrictPtrTraits>(),
+        inv_idx.packed_accessor32<int,2,torch::RestrictPtrTraits>(),
+        total_points
+    );
+
+    // Fill inverse neighbors and k indices
+    fill_inverse_kernel<<<grid, block>>>(
+        neighbor_inds_int.packed_accessor32<int,3,torch::RestrictPtrTraits>(),
+        inv_neighbors.packed_accessor32<int,2,torch::RestrictPtrTraits>(),
+        inv_k.packed_accessor32<int,2,torch::RestrictPtrTraits>(),
+        running_counts.packed_accessor32<int,2,torch::RestrictPtrTraits>(),
+        inv_idx.packed_accessor32<int,2,torch::RestrictPtrTraits>(),
+        total_points
+    );
+
+    return {inv_neighbors.to(neighbor_inds.dtype()), 
+            inv_k.to(neighbor_inds.dtype()), 
+            inv_idx.to(neighbor_inds.dtype())};
 }

--- a/cpp_wrappers/cpp_pcf_kernel/pcf_cuda_kernel.cu
+++ b/cpp_wrappers/cpp_pcf_kernel/pcf_cuda_kernel.cu
@@ -73,11 +73,11 @@ __global__ void pcf_cuda_forward_kernel(
 
 template <typename scalar_t>
 __global__ void pconv_cuda_forward_kernel(
-    const torch::PackedTensorAccessor32<scalar_t,3,torch::RestrictPtrTraits> __restrict__ input,
-    const torch::PackedTensorAccessor32<long,3,torch::RestrictPtrTraits> __restrict__ neighbor_inds,
-    const torch::PackedTensorAccessor32<scalar_t,4,torch::RestrictPtrTraits> __restrict__ weights,
-    const torch::PackedTensorAccessor32<scalar_t,4,torch::RestrictPtrTraits> __restrict__ additional_features,
-    torch::PackedTensorAccessor32<scalar_t,3,torch::RestrictPtrTraits> __restrict__ output)
+    const torch::PackedTensorAccessor32<scalar_t, 3, torch::RestrictPtrTraits> __restrict__ input,
+    const torch::PackedTensorAccessor32<long, 3, torch::RestrictPtrTraits> __restrict__ neighbor_inds,
+    const torch::PackedTensorAccessor32<scalar_t, 4, torch::RestrictPtrTraits> __restrict__ weights,
+    const torch::PackedTensorAccessor32<scalar_t, 4, torch::RestrictPtrTraits> __restrict__ additional_features,
+    torch::PackedTensorAccessor32<scalar_t, 3, torch::RestrictPtrTraits> __restrict__ output)
 {
 /* input: B x M x C_in tensor, B = batch size, M = number of points in the original point cloud, C_in = number of channels, input features
    neighbor_inds: B x N x K tensor, K = neighborhood size, indices of the neighborhood of each point
@@ -90,7 +90,11 @@ __global__ void pconv_cuda_forward_kernel(
    It outputs a tensor of shape B x N x (C_mid * (C_in + C_add)
    It avoids serializing the input hence faster than naive pyTorch implementation
   */
-        int i,k,ii,jj,kk, iter0;
+        
+        extern __shared__ unsigned char memory[];
+        scalar_t* shared_mem = reinterpret_cast<scalar_t*>(memory);
+
+        int i, k, ii, jj, kk, iter0;
         const int B = input.size(0);
         const int N = input.size(1);
         const int Nout = neighbor_inds.size(1);
@@ -99,10 +103,13 @@ __global__ void pconv_cuda_forward_kernel(
         const int C_mid = weights.size(3);
 	const int C_add = additional_features.size(3);
         const int increment = blockDim.x / C_mid;
+
+        scalar_t* shared_input = shared_mem; // Shared memory for input
+        scalar_t* shared_additional = shared_mem + K * C_in; // Shared memory for additional_features
+
         /* parallelize ii and i on blocks */
         // Supposedly blockIdx.x should go up to B * N
-        for (iter0 = blockIdx.x; iter0< B * Nout; iter0+= gridDim.x)
-        {
+        for (iter0 = blockIdx.x; iter0 < B * Nout; iter0 += gridDim.x) {
                 // ii is the index on the batch dimension
                 ii = iter0 / Nout;
                 // i is the index on the point dimension
@@ -114,30 +121,160 @@ __global__ void pconv_cuda_forward_kernel(
                 // Throw out the excessive threads
                 if (jj >= C_mid)
                         continue;
-// This is our main non-contiguous memory access because we need to sparse gather the input
-// But maybe we coalesce memory across all the threads in the block?
-                #pragma unroll
-                for(kk=threadIdx.x % increment;kk<C_in;kk+=increment)
-                {
-                        scalar_t partial_sum = 0.0;
-                        #pragma unroll
-                        for (k=0;k<K;k++)
-                                partial_sum += input[ii][neighbor_inds[ii][i][k]][kk] * weights[ii][i][k][jj];
-                        output[ii][i][jj + kk*C_mid] = partial_sum;
+
+                // Load input data into shared memory
+                for (k = threadIdx.x; k < K * C_in; k += blockDim.x) {
+                        int k_idx = k / C_in;
+                        int c_idx = k % C_in;
+                        shared_input[k] = input[ii][neighbor_inds[ii][i][k_idx]][c_idx];
                 }
-                if (C_add > 0)
-                {
-		    #pragma unroll
-		    for(kk=threadIdx.x % increment;kk<C_add;kk+=increment)
-		    {
-			scalar_t partial_sum = 0.0;
-			#pragma unroll
-			for (k=0;k<K;k++)
-				partial_sum += additional_features[ii][i][k][kk] * weights[ii][i][k][jj];
-			output[ii][i][jj + (kk + C_in)*C_mid] = partial_sum;
-		     }
+
+                // Load additional features into shared memory
+                if (C_add > 0) {
+                        for (k = threadIdx.x; k < K * C_add; k += blockDim.x) {
+                                int k_idx = k / C_add;
+                                int c_idx = k % C_add;
+                                shared_additional[k] = additional_features[ii][i][k_idx][c_idx];
+                        }
+                }
+
+                __syncthreads(); // Synchronize threads after loading shared memory
+
+                // This is our main non-contiguous memory access because we need to sparse gather the input
+                // But maybe we coalesce memory across all the threads in the block?
+                scalar_t partial_sum_1 = 0.0;
+                for(kk = threadIdx.x % increment; kk < C_in; kk += increment) {
+                        #pragma unroll
+                        for (k = 0; k < K; k++) {
+                                partial_sum_1 += shared_input[k * C_in + kk] * weights[ii][i][k][jj];
+                        }
+                        output[ii][i][jj + kk * C_mid] = partial_sum_1;
+                        partial_sum_1 = 0.0;
+                }
+                if (C_add > 0) {
+                        scalar_t partial_sum_2 = 0.0;
+                        for(kk = threadIdx.x % increment; kk < C_add; kk += increment) {
+                                #pragma unroll
+                                for (k = 0; k < K; k++) {
+                                        partial_sum_2 += shared_additional[k * C_add + kk] * weights[ii][i][k][jj];
+                                }
+                                output[ii][i][jj + (kk + C_in) * C_mid] = partial_sum_2;
+                                partial_sum_2 = 0.0;
+                        }
                 }
                 // At this point we would have fully populated the interm array of C_mid * C_in
+
+                __syncthreads();
+	}
+}
+
+template <typename scalar_t>
+__global__ void pconv_linear_cuda_forward_kernel(
+    const torch::PackedTensorAccessor32<scalar_t, 3, torch::RestrictPtrTraits> __restrict__ input,
+    const torch::PackedTensorAccessor32<long, 3, torch::RestrictPtrTraits> __restrict__ neighbor_inds,
+    const torch::PackedTensorAccessor32<scalar_t, 4, torch::RestrictPtrTraits> __restrict__ weights,
+    const torch::PackedTensorAccessor32<scalar_t, 4, torch::RestrictPtrTraits> __restrict__ additional_features,
+    const torch::PackedTensorAccessor32<scalar_t, 2, torch::RestrictPtrTraits> __restrict__ linear_weights,
+    const torch::PackedTensorAccessor32<scalar_t, 1, torch::RestrictPtrTraits> __restrict__ linear_bias,
+    torch::PackedTensorAccessor32<scalar_t, 3, torch::RestrictPtrTraits> __restrict__ final_output)
+{
+/* input: B x M x C_in tensor, B = batch size, M = number of points in the original point cloud, C_in = number of channels, input features
+   neighbor_inds: B x N x K tensor, K = neighborhood size, indices of the neighborhood of each point
+   weights: B x N x K x C_mid, C_mid = number of middle channels
+   additional_features: B x N x K x C_add, additional features that do not require indexing
+   output: B x N x (C_mid*C_in), final output of the PCF layer
+   
+   This implements a fused layer of:
+  concat(sum_{i} input[b,n][neighbor_inds[i]][j] * weights[b,n,k,i], sum_{i} additional_features[b,n][i][j] * weights[b,n,k,i]
+   It outputs a tensor of shape B x N x (C_mid * (C_in + C_add)
+   It avoids serializing the input hence faster than naive pyTorch implementation
+  */
+        
+        extern __shared__ unsigned char memory[];
+        scalar_t* shared_mem = reinterpret_cast<scalar_t*>(memory);
+
+        int i, k, ii, jj, kk, iter0;
+        const int B = input.size(0);
+        const int N = input.size(1);
+        const int Nout = neighbor_inds.size(1);
+        const int C_in = input.size(2);
+        const int K = neighbor_inds.size(2);
+        const int C_mid = weights.size(3);
+	const int C_add = additional_features.size(3);
+        const int C_out = linear_weights.size(0);
+        const int increment = blockDim.x / C_mid;
+
+        // Shared memory
+        scalar_t* shared_input = shared_mem;                            // input
+        scalar_t* shared_additional = shared_mem + K * C_in;            // additional_features
+        scalar_t* shared_fused_output = shared_additional + K * C_add;  // fused output
+
+        /* parallelize ii and i on blocks */
+        // Supposedly blockIdx.x should go up to B * N
+        for (iter0 = blockIdx.x; iter0 < B * Nout; iter0 += gridDim.x) {
+                // ii is the index on the batch dimension
+                ii = iter0 / Nout;
+                // i is the index on the point dimension
+                i = iter0 % Nout;
+                // Suppose each point is a block, then split it into threads
+                // output channels is at least 8, C_mid is usually at least 16, so we are safe dividing on this dimension
+                // C_mid is at most 16, so for sure each C_mid gets its own thread, and maybe we have many threads for the same C_mid
+                jj = threadIdx.x / increment;
+                // Throw out the excessive threads
+                if (jj >= C_mid)
+                        continue;
+
+                // Load input data into shared memory
+                for (k = threadIdx.x; k < K * C_in; k += blockDim.x) {
+                        int k_idx = k / C_in;
+                        int c_idx = k % C_in;
+                        shared_input[k] = input[ii][neighbor_inds[ii][i][k_idx]][c_idx];
+                }
+
+                // Load additional features into shared memory
+                if (C_add > 0) {
+                        for (k = threadIdx.x; k < K * C_add; k += blockDim.x) {
+                                int k_idx = k / C_add;
+                                int c_idx = k % C_add;
+                                shared_additional[k] = additional_features[ii][i][k_idx][c_idx];
+                        }
+                }
+
+                for (int c = threadIdx.x; c < C_mid * (C_in + C_add); c += blockDim.x) {
+                        shared_fused_output[c] = 0.0;
+                }
+
+                __syncthreads(); // Sync threads after loading into shared memory
+
+                // PConv
+                for (kk = threadIdx.x % increment; kk < C_in; kk += increment) {
+                        #pragma unroll
+                        for (k = 0; k < K; k++) {
+                                shared_fused_output[jj + kk * C_mid] += shared_input[k * C_in + kk] * weights[ii][i][k][jj];
+                        }
+                }
+
+                if (C_add > 0) {
+                        for (kk = threadIdx.x % increment; kk < C_add; kk += increment) {
+                                #pragma unroll
+                                for (k = 0; k < K; k++) {
+                                        shared_fused_output[jj + (kk + C_in) * C_mid] += shared_additional[k * C_add + kk] * weights[ii][i][k][jj];
+                                }
+                        }
+                }
+
+                __syncthreads(); // Sync threads before applying linear layer
+
+                // Linear
+                for (int c_out = threadIdx.x; c_out < C_out; c_out += blockDim.x) {
+                        scalar_t linear_sum = 0.0;
+                        for (int c_in = 0; c_in < C_mid * (C_in + C_add); c_in++) {
+                                linear_sum += shared_fused_output[c_in] * linear_weights[c_out][c_in];
+                        }
+                        final_output[ii][i][c_out] = linear_sum + linear_bias[c_out];
+                }
+
+                __syncthreads();
 	}
 }
 
@@ -352,13 +489,58 @@ torch::Tensor pconv_cuda_forward(
         const int C_mid =  weights.size(3);
         const int numBlocks = B * Nout;
         const int numThreads = C_mid * C_in > 256 ? 256 : C_mid * C_in;
-        auto output = torch::zeros({B,Nout,C_mid*(C_in+C_add)}, input.type());
+
+        // Calculate shared memory size for input and additional features
+        const int K = neighbor_inds.size(2);
+        const int shared_mem_size = (K * (C_in + C_add)) * sizeof(float);
+
+        auto output = torch::zeros({B, Nout, C_mid * (C_in + C_add)}, input.type());
+
         AT_DISPATCH_FLOATING_TYPES(output.type(), "pconv_cuda_forward_kernel", ([&] {
-        pconv_cuda_forward_kernel<scalar_t><<<numBlocks, numThreads>>>(
+        pconv_cuda_forward_kernel<scalar_t><<<numBlocks, numThreads, shared_mem_size>>>(
                 input.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>(),
                 neighbor_inds.packed_accessor32<long,3,torch::RestrictPtrTraits>(),
                 weights.packed_accessor32<scalar_t,4,torch::RestrictPtrTraits>(),
 		additional_features.packed_accessor32<scalar_t,4,torch::RestrictPtrTraits>(),
+                output.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>());
+        }));
+        return output;
+}
+
+torch::Tensor pconv_linear_cuda_forward(
+    torch::Tensor input,
+    torch::Tensor neighbor_inds,
+    torch::Tensor weights,
+    torch::Tensor additional_features,
+    torch::Tensor linear_weights,
+    torch::Tensor linear_bias
+)
+{
+        const int B = input.size(0);
+        const int N = input.size(1);
+        const int Nout = neighbor_inds.size(1);
+        const int C_in = input.size(2);
+	const int C_add = additional_features.size(3);
+        const int C_mid =  weights.size(3);
+        const int C_out = linear_weights.size(0);
+        const int numBlocks = B * Nout;
+        const int numThreads = C_mid * C_in > 256 ? 256 : C_mid * C_in;
+
+        // Calculate shared memory size for input, additional features and intermediates
+        const int K = neighbor_inds.size(2);
+        // const int shared_mem_size = (K * (C_in + C_add)) * sizeof(float);
+        const int shared_mem_size = (K * C_in + K * C_add + C_mid * (C_in + C_add)) * sizeof(float);
+
+        auto output = torch::zeros({B, N, C_out}, input.type());
+
+        AT_DISPATCH_FLOATING_TYPES(output.type(), "pconv_linear_cuda_forward_kernel", ([&] {
+        pconv_linear_cuda_forward_kernel<scalar_t><<<numBlocks, numThreads, shared_mem_size>>>(
+                input.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>(),
+                neighbor_inds.packed_accessor32<long,3,torch::RestrictPtrTraits>(),
+                weights.packed_accessor32<scalar_t,4,torch::RestrictPtrTraits>(),
+		additional_features.packed_accessor32<scalar_t,4,torch::RestrictPtrTraits>(),
+                linear_weights.packed_accessor32<scalar_t,2,torch::RestrictPtrTraits>(),
+                linear_bias.packed_accessor32<scalar_t,1,torch::RestrictPtrTraits>(),
                 output.packed_accessor32<scalar_t,3,torch::RestrictPtrTraits>());
         }));
         return output;

--- a/cpp_wrappers/cpp_pcf_kernel/profile.py
+++ b/cpp_wrappers/cpp_pcf_kernel/profile.py
@@ -1,0 +1,236 @@
+import gc
+import time
+import numpy as np
+import torch
+import pcf_cuda
+from pykeops.torch import LazyTensor
+
+from test_kernels import (
+    knn, 
+    PConv, 
+    PConvLinear, 
+    PConvLinearOpt,
+    create_inverse_python
+)
+
+
+def memory_usage_stats():
+    torch.cuda.synchronize()
+    allocated = torch.cuda.memory_allocated() / (1024 * 1024)  # MB
+    reserved = torch.cuda.memory_reserved() / (1024 * 1024)    # MB
+    return allocated, reserved
+
+def print_memory_usage(title, before, after):
+    alloc_diff = after[0] - before[0]
+    res_diff = after[1] - before[1]
+    print(f"{title}: Allocated +{alloc_diff:.2f} MB, Reserved +{res_diff:.2f} MB")
+
+def profile_knn_inverse_memory(n_points=100000, K=64):
+    """
+    Profile memory usage of KNN inverse mapping kernel
+    """
+    device = torch.device("cuda")
+    B = 1  # batch size
+
+    print(f"\n===== Memory profiling for KNN inverse with {n_points} points, K={K} =====")
+
+    # Reset
+    torch.cuda.reset_peak_memory_stats()
+    torch.cuda.empty_cache()
+    gc.collect()
+
+    # Create random pc
+    torch.manual_seed(42)
+    before = memory_usage_stats()
+    input_points = torch.randn(B, n_points, 3, device=device, requires_grad=False)
+    after = memory_usage_stats()
+    print_memory_usage("Point cloud creation", before, after)
+
+    # Compute KNN indices
+    print("\nComputing KNN indices...")
+    before = memory_usage_stats()
+    neighbor_inds = knn(input_points, input_points, K).contiguous()
+    after = memory_usage_stats()
+    print_memory_usage("KNN computation", before, after)
+    total_points = n_points
+
+    # Compute KNN inverse
+    print("\nComputing KNN inverse mapping...")
+    before = memory_usage_stats()
+    peak_before = torch.cuda.max_memory_allocated() / (1024 * 1024)
+
+    outputs = pcf_cuda.compute_knn_inverse(neighbor_inds, total_points)
+    torch.cuda.synchronize()
+
+    after = memory_usage_stats()
+    peak_after = torch.cuda.max_memory_allocated() / (1024 * 1024)
+
+    print_memory_usage("KNN inverse computation", before, after)
+    print(f"Peak memory during KNN inverse: {peak_after:.2f} MB (+{peak_after - peak_before:.2f} MB)")
+
+    print("\nMemory usage of output tensors:")
+    for i, tensor in enumerate(outputs):
+        print(f"  Output tensor {i}: {tensor.element_size() * tensor.numel() / (1024 * 1024):.2f} MB, shape: {tensor.shape}")
+    
+    return outputs, neighbor_inds, total_points
+
+
+def profile_pconv_memory(n_points=100000, K=64):
+    """
+    Profile memory usage of PConv implementations
+    """
+    device = torch.device("cuda")
+    B = 1  # batch size
+
+    # Params
+    C_in = 16       # input feature channels
+    C_add = 16      # additional feature channels
+    C_mid = 16      # mid feature channels - weight dim
+    C_out = 64      # output channels for linear layer
+
+    print(f"\n===== Memory profiling for PConv with {n_points} points, K={K} =====")
+
+    # Reset
+    torch.cuda.reset_peak_memory_stats()
+    torch.cuda.empty_cache()
+    gc.collect()
+
+    print("Creating input tensors...")
+    torch.manual_seed(42)
+
+    before = memory_usage_stats()
+
+    input_points = torch.randn(B, n_points, 3, device=device, requires_grad=True)
+    input_features = torch.randn(B, n_points, C_in, device=device, requires_grad=True)
+    neighbor_inds = knn(input_points, input_points, K).contiguous()
+    inverse_neighbors, inverse_k, inverse_idx = pcf_cuda.compute_knn_inverse(neighbor_inds, input_features.shape[1])
+    weights = torch.randn(B, n_points, K, C_mid, device=device, requires_grad=True)
+    additional_features = torch.randn(B, n_points, K, C_add, device=device, requires_grad=True)
+    linear_weights = torch.randn(C_out, (C_in + C_add) * C_mid, device=device, requires_grad=True)
+    linear_bias = torch.randn(C_out, device=device, requires_grad=True)
+
+    after = memory_usage_stats()
+    print_memory_usage("Input tensor creation total", before, after)
+
+    print("\nIndividual tensor sizes:")
+    print(f"  Input features: {input_features.element_size() * input_features.numel() / (1024 * 1024):.2f} MB, shape: {input_features.shape}")
+    print(f"  Neighbor indices: {neighbor_inds.element_size() * neighbor_inds.numel() / (1024 * 1024):.2f} MB, shape: {neighbor_inds.shape}")
+    print(f"  Inverse neighbors: {inverse_neighbors.element_size() * inverse_neighbors.numel() / (1024 * 1024):.2f} MB, shape: {inverse_neighbors.shape}")
+    print(f"  Weights: {weights.element_size() * weights.numel() / (1024 * 1024):.2f} MB, shape: {weights.shape}")
+    print(f"  Additional features: {additional_features.element_size() * additional_features.numel() / (1024 * 1024):.2f} MB, shape: {additional_features.shape}")
+
+    # Init
+    pconv = PConv()
+    linear_layer = torch.nn.Linear((C_in + C_add) * C_mid, C_out).to(device)
+    linear_layer.weight.data.copy_(linear_weights)
+    linear_layer.bias.data.copy_(linear_bias)
+
+    pconv_linear = PConvLinear((C_in + C_add) * C_mid, C_out)
+    pconv_linear.linear.weight.data.copy_(linear_weights)
+    pconv_linear.linear.bias.data.copy_(linear_bias)
+    pconv_linear = pconv_linear.cuda()
+
+    pconv_linear_opt = PConvLinearOpt((C_in + C_add) * C_mid, C_out)
+    pconv_linear_opt.linear.weight.data.copy_(linear_weights)
+    pconv_linear_opt.linear.bias.data.copy_(linear_bias)
+    pconv_linear_opt = pconv_linear_opt.cuda()
+
+    # Dummy gradient
+    grad_output = torch.randn(B, n_points, C_out, device=device)
+
+    implementations = [
+        {
+            "name": "Unfused (PConv + Linear)",
+            "forward": lambda: (pconv(input_features, neighbor_inds, weights, additional_features), linear_layer),
+            "backward": lambda out_tuple: linear_layer(out_tuple[0]).backward(grad_output)
+        },
+        {
+            "name": "Fused (PConvLinear)",
+            "forward": lambda: pconv_linear(input_features, neighbor_inds, weights, additional_features),
+            "backward": lambda out: out.backward(grad_output)
+        },
+        {
+            "name": "Optimized Fused (PConvLinearOpt)",
+            "forward": lambda: pconv_linear_opt(input_features, neighbor_inds, inverse_neighbors, inverse_k, inverse_idx, weights, additional_features),
+            "backward": lambda out: out.backward(grad_output)
+        }
+    ]
+
+    # Profile
+    for impl in implementations:
+        print(f"\n----- {impl['name']} -----")
+    
+        # Reset
+        torch.cuda.reset_peak_memory_stats()
+        torch.cuda.empty_cache()
+        input_features.grad = None
+        weights.grad = None
+        additional_features.grad = None
+        if "linear_layer" in locals():
+            linear_layer.weight.grad = None
+            linear_layer.bias.grad = None
+        if "pconv_linear" in locals():
+            pconv_linear.linear.weight.grad = None
+            pconv_linear.linear.bias.grad = None
+        if "pconv_linear_opt" in locals():
+            pconv_linear_opt.linear.weight.grad = None
+            pconv_linear_opt.linear.bias.grad = None
+
+        # Forward pass
+        before_forward = memory_usage_stats()
+        peak_before_forward = torch.cuda.max_memory_allocated() / (1024 * 1024)
+
+        torch.cuda.nvtx.range_push(f"{impl['name']}_FORWARD")
+        out = impl["forward"]()
+        torch.cuda.synchronize()
+        torch.cuda.nvtx.range_pop()
+
+        after_forward = memory_usage_stats()
+        peak_after_forward = torch.cuda.max_memory_allocated() / (1024 * 1024)
+
+        print_memory_usage("Forward pass", before_forward, after_forward)
+        print(f"Peak memory during forward: {peak_after_forward:.2f} MB (+{peak_after_forward - peak_before_forward:.2f} MB)")
+
+        # Backward pass
+        before_backward = memory_usage_stats()
+        peak_before_backward = torch.cuda.max_memory_allocated() / (1024 * 1024)
+
+        torch.cuda.nvtx.range_push(f"{impl['name']}_BACKWARD")
+        impl["backward"](out)
+        torch.cuda.synchronize()
+        torch.cuda.nvtx.range_pop()
+
+        after_backward = memory_usage_stats()
+        peak_after_backward = torch.cuda.max_memory_allocated() / (1024 * 1024)
+
+        print_memory_usage("Backward pass", before_backward, after_backward)
+        print(f"Peak memory during backward: {peak_after_backward:.2f} MB (+{peak_after_backward - peak_before_backward:.2f} MB)")
+        print(f"Total peak memory: {peak_after_backward:.2f} MB")
+
+        del out
+
+
+def main():
+    import sys
+    if len(sys.argv) > 1:
+        n_points = int(sys.argv[1])
+    else:
+        n_points = 100000
+
+    if len(sys.argv) > 2:
+        K = int(sys.argv[2])
+    else:
+        K = 64
+
+    print(f"PyTorch CUDA available: {torch.cuda.is_available()}")
+    print(f"GPU: {torch.cuda.get_device_name(0)}")
+    print(f"Configuration: {n_points} points, K={K}")
+
+    profile_knn_inverse_memory(n_points, K)
+    profile_pconv_memory(n_points, K)
+
+    print("\nMemory profiling completed successfully")
+
+
+if __name__ == "__main__":
+    main()

--- a/cpp_wrappers/cpp_pcf_kernel/setup.py
+++ b/cpp_wrappers/cpp_pcf_kernel/setup.py
@@ -15,7 +15,12 @@ setup(
         CUDAExtension('pcf_cuda', [
             'pcf_cuda.cpp',
             'pcf_cuda_kernel.cu',
-        ], extra_compile_args={'nvcc': ['-L/usr/local/cuda/lib64 -lcudadevrt -lcudart']})
+        ],
+        include_dirs=[
+            '/nfs/stak/users/sivakuml/hpc-memory/cutlass/cutlass/include',
+            '/nfs/stak/users/sivakuml/hpc-memory/cutlass/cutlass/tools/util/include',
+            ],
+        extra_compile_args={'nvcc': ['-L/usr/local/cuda/lib64 -lcudadevrt -lcudart']})
     ],
     cmdclass={
         'build_ext': BuildExtension

--- a/cpp_wrappers/cpp_pcf_kernel/test_kernels.py
+++ b/cpp_wrappers/cpp_pcf_kernel/test_kernels.py
@@ -1,0 +1,129 @@
+import time
+import torch
+import pcf_cuda
+import torch.cuda.profiler as profiler
+
+
+# class PConvFunction(torch.autograd.Function):
+#     @staticmethod
+#     def forward(
+#             ctx,
+#             input_feat,
+#             neighbor_inds,
+#             weightnet,
+#             additional_features):
+#         neighbor_inds.requires_grad = False
+#         output = pcf_cuda.pconv_forward(
+#             input_feat, neighbor_inds, weightnet, additional_features)
+#         return output
+
+#     @staticmethod
+#     def backward(ctx, grad_output):
+#         grad_input, grad_weight, grad_additional = pcf_cuda.pconv_backward(
+#             grad_output.contiguous(), *ctx.saved_tensors)
+#         return grad_input, None, grad_weight, grad_additional
+
+
+# class PConv(torch.nn.Module):
+#     def __init__(self):
+#         super(PConv, self).__init__()
+
+#     @staticmethod
+#     def forward(input_features, neighbor_inds, weightnet, additional_features=None):
+#         if additional_features is None:
+#             additional_features = torch.zeros(input_features.shape[0], input_features.shape[1], neighbor_inds.shape[2], 0)
+#         return PConvFunction.apply(
+#             input_features,
+#             neighbor_inds,
+#             weightnet,
+#             additional_features)
+
+
+# class PConvFunction(torch.autograd.Function):
+#     @staticmethod
+#     def forward(
+#             ctx,
+#             input_feat,
+#             neighbor_inds,
+#             weightnet,
+#             additional_features,
+#             linear_weights,
+#             linear_bias):
+#         neighbor_inds.requires_grad = False
+#         output = pcf_cuda.pconv_forward(
+#             input_feat, neighbor_inds, weightnet, additional_features, linear_weights, linear_bias)
+#         return output
+
+#     @staticmethod
+#     def backward(ctx, grad_output):
+#         grad_input, grad_weight, grad_additional = pcf_cuda.pconv_backward(
+#             grad_output.contiguous(), *ctx.saved_tensors)
+#         return grad_input, None, grad_weight, grad_additional
+
+
+# class PConv(torch.nn.Module):
+#     def __init__(self):
+#         super(PConv, self).__init__()
+
+#     @staticmethod
+#     def forward(input_features, neighbor_inds, weightnet, linear_weights, linear_bias, additional_features=None):
+#         if additional_features is None:
+#             additional_features = torch.zeros(input_features.shape[0], input_features.shape[1], neighbor_inds.shape[2], 0)
+#         return PConvFunction.apply(
+#             input_features,
+#             neighbor_inds,
+#             weightnet,
+#             additional_features,
+#             linear_weights,
+#             linear_bias)
+
+
+
+feats_x = torch.load("data/feat_x.pt").to(device=torch.device("cuda")).contiguous()
+nei_inds = torch.load("data/nei_inds.pt").to(device=torch.device("cuda")).contiguous()
+weights = torch.load("data/weights.pt").to(device=torch.device("cuda")).contiguous()
+feat_pe = torch.load("data/feat_pe.pt").to(device=torch.device("cuda")).contiguous()
+linear_weights = torch.load("data/linear_weights.pt").to(device=torch.device("cuda"))
+linear_bias = torch.load("data/linear_bias.pt").to(device=torch.device("cuda"))
+
+out_channel = 64
+last_ch = 16
+weightnet_dim = 16
+linear_layer = torch.nn.Linear((out_channel // 4 + last_ch) * weightnet_dim, out_channel // 2).to(device=torch.device("cuda"))
+linear_layer.weight.data.copy_(linear_weights)
+linear_layer.bias.data.copy_(linear_bias)
+
+torch.cuda.synchronize()
+
+num_runs = 100
+total_time = 0
+for num_run in range(num_runs):
+    start = time.time()
+    output = pcf_cuda.pconv_forward(feats_x, nei_inds, weights, feat_pe)
+    output = linear_layer(output)
+    total_time += (time.time() - start)
+
+average_time = (total_time / num_runs) * 1000
+print(f"Average Time: {average_time} ms")
+
+
+total_time = 0
+for num_run in range(num_runs):
+    start = time.time()
+    output = pcf_cuda.pconv_linear_forward(feats_x, nei_inds, weights, feat_pe, linear_weights, linear_bias)
+    total_time += (time.time() - start)
+
+average_time = (total_time / num_runs) * 1000
+print(f"(Fused) PConv + Linear -> Average Time: {average_time} ms")
+
+
+
+#############
+# Check Equal
+#############
+out_1 = pcf_cuda.pconv_forward(feats_x, nei_inds, weights, feat_pe)
+out_1 = linear_layer(out_1)
+
+out_2 = pcf_cuda.pconv_linear_forward(feats_x, nei_inds, weights, feat_pe, linear_weights, linear_bias)
+
+print(f"Two Tensors are Equal? {torch.allclose(out_1, out_2, atol=1e-5, rtol=1e-5)}")

--- a/cpp_wrappers/cpp_pcf_kernel/test_kernels.py
+++ b/cpp_wrappers/cpp_pcf_kernel/test_kernels.py
@@ -410,10 +410,10 @@ def test_knn_inv():
         return total_diff
 
 
-    B = 16          # batch size (meh!!)
-    N = 2048        # number of points 
+    B = 4          # batch size (meh!!)
+    N = 100000        # number of points 
     C_in = 3        # number of inp channels
-    K = 48          # number of neighbors
+    K = 100          # number of neighbors
     total_points = N
     num_runs = 100
 
@@ -568,6 +568,6 @@ def test_knn_inv():
 
 
 if __name__ == "__main__":
-    test_pconv_linear()
-    test_pconv_linear_with_memory()
+    # test_pconv_linear()
+    # test_pconv_linear_with_memory()
     test_knn_inv()

--- a/cpp_wrappers/cpp_pcf_kernel/test_kernels.py
+++ b/cpp_wrappers/cpp_pcf_kernel/test_kernels.py
@@ -110,6 +110,49 @@ class PConvLinearOpt(torch.nn.Module):
                                                 weightnet, additional_features, self.linear.weight, self.linear.bias)
 
 
+class PConvLinearCutlassFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, input_feat, neighbor_inds, inverse_neighbors, inverse_k, inverse_idx,
+                        weightnet, additional_features, linear_weights, linear_bias):
+        neighbor_inds.requires_grad = False
+
+        output, pconv_output = pcf_cuda.pconv_linear_cutlass_forward(
+            input_feat, neighbor_inds, weightnet, additional_features, 
+            linear_weights, linear_bias)
+
+        ctx.save_for_backward(input_feat, inverse_neighbors, inverse_k, inverse_idx, 
+                            neighbor_inds, weightnet, additional_features, 
+                            linear_weights, pconv_output)
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        saved = ctx.saved_tensors
+        input_feat, inverse_neighbors, inverse_k, inverse_idx, neighbor_inds, \
+        weightnet, additional_features, linear_weights, pconv_output = saved
+
+        grad_output = grad_output.contiguous()
+
+        grads = pcf_cuda.pconv_linear_opt_backward(
+            grad_output, input_feat, inverse_neighbors, inverse_k, 
+            inverse_idx, neighbor_inds, weightnet, additional_features,
+            linear_weights, pconv_output)
+
+        return grads[0], None, None, None, None, grads[1], grads[2], grads[3], grads[4]
+
+class PConvLinearCutlass(torch.nn.Module):
+    def __init__(self, in_features, out_features):
+        super(PConvLinearCutlass, self).__init__()
+        self.linear = torch.nn.Linear(in_features, out_features)
+
+    def forward(self, input_features, neighbor_inds, inverse_neighbors, inverse_k, inverse_idx, weightnet, additional_features=None):
+        if additional_features is None:
+            additional_features = torch.zeros(input_features.shape[0], input_features.shape[1], 
+                                          neighbor_inds.shape[2], 0, device=input_features.device)
+        return PConvLinearCutlassFunction.apply(input_features, neighbor_inds, inverse_neighbors, inverse_k, inverse_idx,
+                                                weightnet, additional_features, self.linear.weight, self.linear.bias)
+
+
 def knn(pts1, pts2, k):
     """
     Find the k-nearest neighbors for each point in pts1 from pts2
@@ -1251,6 +1294,230 @@ def test_pconv_linear_opt_random(point_sizes=[50000, 100000, 200000], K=64, num_
     return results
 
 
+def test_pconv_linear_cutlass_random(point_sizes=[50000, 100000, 200000], K=64, num_runs=5):
+    """
+    Test PConv + Linear optimization with random data
+
+    Args:
+        point_sizes: Number of points
+        K: Number of neighbors
+        num_runs: Number of runs for each point size
+
+    Returns:
+        Dict of results
+    """
+
+    device = torch.device("cuda")
+    torch.manual_seed(42)
+    
+    # Params
+    B = 1           # batch size
+    C_in = 16       # input feature channels 
+    C_add = 16      # additional feature channels
+    C_mid = 16      # mid feature channels - weight dim
+    C_out = 64      # output channels for linear layer
+
+    results = {
+        'point_sizes': point_sizes,
+        'unfused': {'forward': [], 'backward': [], 'total': [], 'memory': []},
+        'fused': {'forward': [], 'backward': [], 'total': [], 'memory': []},
+        'opt_fused': {'forward': [], 'backward': [], 'total': [], 'memory': []}
+    }
+
+    for n_points in point_sizes:
+        print(f"\n\n===== Testing with {n_points} points =====")
+
+        input_points = torch.randn(B, n_points, 3, device=device, requires_grad=True)
+        input_features = torch.randn(B, n_points, C_in, device=device, requires_grad=True)
+
+        print("Calculating KNN indices and Inverse indices...")
+        neighbor_inds = knn(input_points, input_points, K).contiguous()
+        inverse_neighbors, inverse_k, inverse_idx = pcf_cuda.compute_knn_inverse(neighbor_inds, input_features.shape[1])
+        torch.cuda.synchronize()
+        print(f"KNN indices shape: {neighbor_inds.shape}")
+        print(f"KNN inverse indices shape: inv nei-{inverse_neighbors.shape}, inv k-{inverse_k.shape}, inv idx-{inverse_idx.shape}")
+
+        weights = torch.randn(B, n_points, K, C_mid, device=device, requires_grad=True)
+        additional_features = torch.randn(B, n_points, K, C_add, device=device, requires_grad=True)
+        linear_weights = torch.randn(C_out, (C_in + C_add) * C_mid, device=device, requires_grad=True)
+        linear_bias = torch.randn(C_out, device=device, requires_grad=True)
+
+        # Init
+        pconv = PConv()
+        linear_layer = torch.nn.Linear((C_in + C_add) * C_mid, C_out).to(device)
+        linear_layer.weight.data.copy_(linear_weights)
+        linear_layer.bias.data.copy_(linear_bias)
+
+        pconv_linear = PConvLinear((C_in + C_add) * C_mid, C_out)
+        pconv_linear.linear.weight.data.copy_(linear_weights)
+        pconv_linear.linear.bias.data.copy_(linear_bias)
+        pconv_linear = pconv_linear.cuda()
+
+        pconv_linear_opt = PConvLinearCutlass((C_in + C_add) * C_mid, C_out)
+        pconv_linear_opt.linear.weight.data.copy_(linear_weights)
+        pconv_linear_opt.linear.bias.data.copy_(linear_bias)
+        pconv_linear_opt = pconv_linear_opt.cuda()
+
+        # Dummy gradient for backward pass
+        grad_output = torch.randn(B, n_points, C_out, device=device)
+
+        print("Performing warm-up runs...")
+        for _ in range(2):
+            # Unfused
+            pconv_out = pconv(input_features, neighbor_inds, weights, additional_features)
+            out_unfused = linear_layer(pconv_out)
+            out_unfused.backward(grad_output)
+
+            input_features.grad = None
+            weights.grad = None
+            additional_features.grad = None
+            linear_layer.weight.grad = None
+            linear_layer.bias.grad = None
+
+            # Fused
+            out_fused = pconv_linear(input_features, neighbor_inds, weights, additional_features)
+            out_fused.backward(grad_output)
+
+            input_features.grad = None
+            weights.grad = None
+            additional_features.grad = None
+            pconv_linear.linear.weight.grad = None
+            pconv_linear.linear.bias.grad = None
+
+            # Optimized fused
+            out_opt_fused = pconv_linear_opt(input_features, neighbor_inds, inverse_neighbors, inverse_k, inverse_idx,
+                                                weights, additional_features)
+            out_opt_fused.backward(grad_output)
+
+            input_features.grad = None
+            weights.grad = None
+            additional_features.grad = None
+            pconv_linear_opt.linear.weight.grad = None
+            pconv_linear_opt.linear.bias.grad = None
+
+
+        unfused_times = {'forward': [], 'backward': [], 'memory': []}
+        fused_times = {'forward': [], 'backward': [], 'memory': []}
+        opt_fused_times = {'forward': [], 'backward': [], 'memory': []}
+
+        print(f"Running benchmark with {num_runs} iterations for each implementation...")
+        for r in range(num_runs):
+            print(f"Run {r+1}/{num_runs}")
+
+            # ----- Unfused -----
+            torch.cuda.empty_cache()
+            gc.collect()
+            torch.cuda.reset_peak_memory_stats()
+            torch.cuda.synchronize()
+            mem_before = torch.cuda.memory_allocated()
+
+            # Forward
+            torch.cuda.synchronize()
+            start = time.time()
+            pconv_out = pconv(input_features, neighbor_inds, weights, additional_features)
+            out_unfused = linear_layer(pconv_out)
+            torch.cuda.synchronize()
+            forward_time = time.time() - start
+
+            # Backward
+            input_features.grad = None
+            weights.grad = None
+            additional_features.grad = None
+            linear_layer.weight.grad = None
+            linear_layer.bias.grad = None
+
+            torch.cuda.synchronize()
+            start = time.time()
+            out_unfused.backward(grad_output)
+            torch.cuda.synchronize()
+            backward_time = time.time() - start
+
+            memory_used = torch.cuda.max_memory_allocated() - mem_before
+
+            unfused_times['forward'].append(forward_time * 1000)        # ms
+            unfused_times['backward'].append(backward_time * 1000)      # ms
+            unfused_times['memory'].append(memory_used / (1024 ** 2))   # MB
+
+            # ----- Fused -----
+            torch.cuda.reset_peak_memory_stats()
+            torch.cuda.synchronize()
+            mem_before = torch.cuda.memory_allocated()
+
+            # Forward
+            torch.cuda.synchronize()
+            start = time.time()
+            out_fused = pconv_linear(input_features, neighbor_inds, weights, additional_features)
+            torch.cuda.synchronize()
+            forward_time = time.time() - start
+
+            # Backward
+            input_features.grad = None
+            weights.grad = None
+            additional_features.grad = None
+            pconv_linear.linear.weight.grad = None
+            pconv_linear.linear.bias.grad = None
+
+            torch.cuda.synchronize()
+            start = time.time()
+            out_fused.backward(grad_output)
+            torch.cuda.synchronize()
+            backward_time = time.time() - start
+
+            memory_used = torch.cuda.max_memory_allocated() - mem_before
+
+            fused_times['forward'].append(forward_time * 1000)          # ms
+            fused_times['backward'].append(backward_time * 1000)        # ms
+            fused_times['memory'].append(memory_used / (1024 ** 2))     # MB
+
+            # ----- Optimized Fused -----
+            torch.cuda.reset_peak_memory_stats()
+            torch.cuda.synchronize()
+            mem_before = torch.cuda.memory_allocated()
+
+            # Forward
+            torch.cuda.synchronize()
+            start = time.time()
+            out_opt_fused = pconv_linear_opt(input_features, neighbor_inds, inverse_neighbors, inverse_k, inverse_idx, weights, additional_features)
+            torch.cuda.synchronize()
+            forward_time = time.time() - start
+
+            # Backward
+            input_features.grad = None
+            weights.grad = None
+            additional_features.grad = None
+            pconv_linear_opt.linear.weight.grad = None
+            pconv_linear_opt.linear.bias.grad = None
+
+            torch.cuda.synchronize()
+            start = time.time()
+            out_opt_fused.backward(grad_output)
+            torch.cuda.synchronize()
+            backward_time = time.time() - start
+
+            memory_used = torch.cuda.max_memory_allocated() - mem_before
+
+            opt_fused_times['forward'].append(forward_time * 1000)          # ms
+            opt_fused_times['backward'].append(backward_time * 1000)        # ms
+            opt_fused_times['memory'].append(memory_used / (1024 ** 2))     # MB
+
+
+        for impl, times in [('unfused', unfused_times), 
+                            ('fused', fused_times), 
+                            ('opt_fused', opt_fused_times)]:
+            results[impl]['forward'].append(np.mean(times['forward']))
+            results[impl]['backward'].append(np.mean(times['backward']))
+            results[impl]['total'].append(np.mean(times['forward']) + np.mean(times['backward']))
+            results[impl]['memory'].append(np.mean(times['memory']))
+
+            print(f"\n{impl.upper()} results for {n_points} points:")
+            print(f"  Forward time: {np.mean(times['forward']):.2f} ± {np.std(times['forward']):.2f} ms")
+            print(f"  Backward time: {np.mean(times['backward']):.2f} ± {np.std(times['backward']):.2f} ms")
+            print(f"  Total time: {np.mean(times['forward']) + np.mean(times['backward']):.2f} ms")
+            print(f"  Memory usage: {np.mean(times['memory']):.2f} ± {np.std(times['memory']):.2f} MB")
+
+    return results
+
+
 def plot_knn_inv_benchmark(results):
     point_sizes = results['point_sizes']
     k_values = results['k_values']
@@ -1437,6 +1704,355 @@ def plot_pconv_linear_opt_benchmark(results):
     plt.show()
 
 
+def test_cutlass_vs_cuda_kernel():
+    device = torch.device("cuda")
+    torch.manual_seed(42)
+
+    B = 2
+    M = 512        # input points
+    Nout = 256     # output points
+    K = 16         # neighbors
+    C_in = 8
+    C_add = 4
+    C_mid = 8
+    C_out = 16
+    C_concat = C_in + C_add
+
+    input = torch.rand(B, M, C_in, device=device)
+    neighbor_inds = torch.randint(0, M, (B, Nout, K), dtype=torch.int64, device=device)
+    additional_features = torch.rand(B, Nout, K, C_add, device=device)
+    weights = torch.rand(B, Nout, K, C_mid, device=device)
+    linear_weights = torch.rand(C_out, C_concat * C_mid, device=device)
+    linear_bias = torch.rand(C_out, device=device)
+
+    input.requires_grad_()
+    weights.requires_grad_()
+    additional_features.requires_grad_()
+    linear_weights.requires_grad_()
+    linear_bias.requires_grad_()
+
+    # CUDA
+    out_cuda, pconv_out_cuda = pcf_cuda.pconv_linear_forward(
+        input, neighbor_inds, weights, additional_features, linear_weights, linear_bias
+    )
+
+    # CUTLASS
+    out_cutlass, pconv_out_cutlass = pcf_cuda.pconv_linear_cutlass_forward(
+        input, neighbor_inds, weights, additional_features, linear_weights, linear_bias
+    )
+
+    print("\n--- Output Shapes ---")
+    print("final_output: ", out_cuda.shape)
+    print("pconv_output: ", pconv_out_cuda.shape)
+
+    # Compare max abs diff
+    diff_final = (out_cuda - out_cutlass).abs().max().item()
+    diff_pconv = (pconv_out_cuda - pconv_out_cutlass).abs().max().item()
+
+    print("\n--- Forward Max Differences ---")
+    print(f"Max diff (final_output): {diff_final:.6f}")
+    print(f"Max diff (pconv_output): {diff_pconv:.6f}")
+
+    try:
+        torch.testing.assert_close(
+            out_cuda, out_cutlass, rtol=1e-4, atol=1e-4,
+            msg="Final output mismatch between CUDA and CUTLASS"
+        )
+        torch.testing.assert_close(
+            pconv_out_cuda, pconv_out_cutlass, rtol=1e-4, atol=1e-4,
+            msg="PConv intermediate output mismatch between CUDA and CUTLASS"
+        )
+        print("CUDA and CUTLASS outputs match for final_output and pconv_output!")
+
+    except AssertionError as e:
+        print("Mismatch detected!")
+        print(str(e))
+
+
+def test_pconv_linear_cutlass():
+    path = "/nfs/stak/users/sivakuml/hpc-memory/cutlass/data/500000pts"
+    device = torch.device("cuda")
+    
+    feats_x = torch.load(f"{path}/feat_x.pt").to(device).contiguous()
+    nei_inds = torch.load(f"{path}/nei_inds.pt").to(device).contiguous()
+    weights = torch.load(f"{path}/weights.pt").to(device).contiguous()
+    feat_pe = torch.load(f"{path}/feat_pe.pt").to(device).contiguous()
+    linear_weights = torch.load(f"{path}/linear_weights.pt").to(device).contiguous()
+    linear_bias = torch.load(f"{path}/linear_bias.pt").to(device).contiguous()
+
+    inverse_neighbors, inverse_k, inverse_idx = pcf_cuda.compute_knn_inverse(nei_inds, feats_x.shape[1])
+
+    out_channel = 64
+    last_ch = 16
+    weightnet_dim = 16
+
+    # Unfused
+    pconv = PConv()
+    linear_layer = torch.nn.Linear((out_channel // 4 + last_ch) * weightnet_dim, out_channel // 2).to(device)
+    linear_layer.weight.data.copy_(linear_weights)
+    linear_layer.bias.data.copy_(linear_bias)
+
+    # PConvLinear
+    pconv_linear = PConvLinear((out_channel // 4 + last_ch) * weightnet_dim, out_channel // 2)
+    pconv_linear.linear.weight.data.copy_(linear_weights)
+    pconv_linear.linear.bias.data.copy_(linear_bias)
+    pconv_linear = pconv_linear.cuda()
+
+    # Optimized PConvLinear
+    pconv_linear_opt = PConvLinearCutlass((out_channel // 4 + last_ch) * weightnet_dim, out_channel // 2)
+    pconv_linear_opt.linear.weight.data.copy_(linear_weights)
+    pconv_linear_opt.linear.bias.data.copy_(linear_bias)
+    pconv_linear_opt = pconv_linear_opt.cuda()
+
+    # dummy gradient
+    grad_output = torch.randn_like(pconv_linear.linear(torch.empty(feats_x.shape[0], feats_x.shape[1], 
+                                              (out_channel // 4 + last_ch) * weightnet_dim, device=device)))
+
+    # -------------- Correctness Check ---------------
+    # Forward & Backward (Unfused)
+    pconv_out = pconv(feats_x, nei_inds, weights, feat_pe)
+    out_unfused = linear_layer(pconv_out)
+    out_unfused.backward(grad_output)
+
+    torch.cuda.synchronize()
+
+    unfused_grads = {
+        "input": feats_x.grad.clone(),
+        "weightnet": weights.grad.clone(),
+        "additional": feat_pe.grad.clone(),
+        "linear_weight": linear_layer.weight.grad.clone(),
+        "linear_bias": linear_layer.bias.grad.clone()
+    }
+
+    feats_x.grad = None
+    weights.grad = None
+    feat_pe.grad = None
+    linear_layer.weight.grad = None
+    linear_layer.bias.grad = None
+
+    # Forward & Backward (Regular Fused)
+    out_fused = pconv_linear(feats_x, nei_inds, weights, feat_pe)
+    out_fused.backward(grad_output)
+
+    torch.cuda.synchronize()
+
+    regular_fused_grads = {
+        "input": feats_x.grad.clone(),
+        "weightnet": weights.grad.clone(),
+        "additional": feat_pe.grad.clone(),
+        "linear_weight": pconv_linear.linear.weight.grad.clone(),
+        "linear_bias": pconv_linear.linear.bias.grad.clone()
+    }
+
+    feats_x.grad = None
+    weights.grad = None
+    feat_pe.grad = None
+    pconv_linear.linear.weight.grad = None
+    pconv_linear.linear.bias.grad = None
+
+    # Forward & Backward (Optimized Fused)
+    out_opt_fused = pconv_linear_opt(feats_x, nei_inds, inverse_neighbors, inverse_k, inverse_idx, weights, feat_pe)
+    out_opt_fused.backward(grad_output)
+
+    torch.cuda.synchronize()
+
+    opt_fused_grads = {
+        "input": feats_x.grad.clone(),
+        "weightnet": weights.grad.clone(),
+        "additional": feat_pe.grad.clone(),
+        "linear_weight": pconv_linear_opt.linear.weight.grad.clone(),
+        "linear_bias": pconv_linear_opt.linear.bias.grad.clone()
+    }
+
+
+    print("\n---------- Correctness Check ----------")
+    print("Forward output differences:")
+    print("  Unfused vs Regular Fused:", torch.max(torch.abs(out_unfused - out_fused)).item())
+    print("  Unfused vs Optimized Fused:", torch.max(torch.abs(out_unfused - out_opt_fused)).item())
+    print("  Regular Fused vs Optimized Fused:", torch.max(torch.abs(out_fused - out_opt_fused)).item())
+
+    print("\nGradient differences (max absolute error):")
+    for key in unfused_grads:
+        diff_unfused_reg = torch.max(torch.abs(unfused_grads[key] - regular_fused_grads[key])).item()
+        diff_unfused_opt = torch.max(torch.abs(unfused_grads[key] - opt_fused_grads[key])).item()
+        diff_reg_opt = torch.max(torch.abs(regular_fused_grads[key] - opt_fused_grads[key])).item()
+
+        print(f"\n{key:13} grad differences:")
+        print(f"  Unfused vs Regular Fused: {diff_unfused_reg:.6f}")
+        print(f"  Unfused vs Optimized Fused: {diff_unfused_opt:.6f}")
+        print(f"  Regular Fused vs Optimized Fused: {diff_reg_opt:.6f}")
+
+        print(f"{key:13} stats:")
+        print(f"  Unfused    - min: {unfused_grads[key].min().item():.6f}, max: {unfused_grads[key].max().item():.6f}, mean: {unfused_grads[key].mean().item():.6f}")
+        print(f"  Reg Fused  - min: {regular_fused_grads[key].min().item():.6f}, max: {regular_fused_grads[key].max().item():.6f}, mean: {regular_fused_grads[key].mean().item():.6f}")
+        print(f"  Opt Fused  - min: {opt_fused_grads[key].min().item():.6f}, max: {opt_fused_grads[key].max().item():.6f}, mean: {opt_fused_grads[key].mean().item():.6f}")
+
+
+    print("\n---------- Performance Benchmarking ----------")
+    num_runs = 100
+    torch.cuda.synchronize()
+
+    # Unfused
+    total_time_forward = 0
+    total_time_backward = 0
+    for _ in range(num_runs):
+        torch.cuda.synchronize()
+        start = time.time()
+        pconv_out = pconv(feats_x, nei_inds, weights, feat_pe)
+        out_unfused = linear_layer(pconv_out)
+        torch.cuda.synchronize()
+        total_time_forward += (time.time() - start)
+
+        feats_x.grad = None
+        weights.grad = None
+        feat_pe.grad = None
+        linear_layer.weight.grad = None
+        linear_layer.bias.grad = None
+
+        torch.cuda.synchronize()
+        start = time.time()
+        out_unfused.backward(grad_output, retain_graph=True)
+        torch.cuda.synchronize()
+        total_time_backward += (time.time() - start)
+
+    print(f"(Unfused) Average Forward Time: {(total_time_forward / num_runs) * 1000:.2f} ms")
+    print(f"(Unfused) Average Backward Time: {(total_time_backward / num_runs) * 1000:.2f} ms")
+    print(f"(Unfused) Average Total Time: {((total_time_forward + total_time_backward) / num_runs) * 1000:.2f} ms")
+
+    # Regular fused
+    total_time_forward = 0
+    total_time_backward = 0
+    for _ in range(num_runs):
+        torch.cuda.synchronize()
+        start = time.time()
+        out_fused = pconv_linear(feats_x, nei_inds, weights, feat_pe)
+        torch.cuda.synchronize()
+        total_time_forward += (time.time() - start)
+
+        feats_x.grad = None
+        weights.grad = None
+        feat_pe.grad = None
+        pconv_linear.linear.weight.grad = None
+        pconv_linear.linear.bias.grad = None
+
+        torch.cuda.synchronize()
+        start = time.time()
+        out_fused.backward(grad_output, retain_graph=True)
+        torch.cuda.synchronize()
+        total_time_backward += (time.time() - start)
+
+    print(f"(Regular Fused) Average Forward Time: {(total_time_forward / num_runs) * 1000:.2f} ms")
+    print(f"(Regular Fused) Average Backward Time: {(total_time_backward / num_runs) * 1000:.2f} ms")
+    print(f"(Regular Fused) Average Total Time: {((total_time_forward + total_time_backward) / num_runs) * 1000:.2f} ms")
+
+    # Optimized fused
+    total_time_forward = 0
+    total_time_backward = 0
+    for _ in range(num_runs):
+        torch.cuda.synchronize()
+        start = time.time()
+        out_opt_fused = pconv_linear_opt(feats_x, nei_inds, inverse_neighbors, inverse_k, inverse_idx, weights, feat_pe)
+        torch.cuda.synchronize()
+        total_time_forward += (time.time() - start)
+
+        feats_x.grad = None
+        weights.grad = None
+        feat_pe.grad = None
+        pconv_linear_opt.linear.weight.grad = None
+        pconv_linear_opt.linear.bias.grad = None
+
+        torch.cuda.synchronize()
+        start = time.time()
+        out_opt_fused.backward(grad_output, retain_graph=True)
+        torch.cuda.synchronize()
+        total_time_backward += (time.time() - start)
+
+    print(f"(Optimized Fused) Average Forward Time: {(total_time_forward / num_runs) * 1000:.2f} ms")
+    print(f"(Optimized Fused) Average Backward Time: {(total_time_backward / num_runs) * 1000:.2f} ms")
+    print(f"(Optimized Fused) Average Total Time: {((total_time_forward + total_time_backward) / num_runs) * 1000:.2f} ms")
+
+
+    print("\n---------- Memory Usage Test ----------")
+    # Unfused
+    torch.cuda.reset_peak_memory_stats()
+    torch.cuda.synchronize()
+    mem_before = torch.cuda.memory_allocated()
+
+    # Forward
+    pconv_out = pconv(feats_x, nei_inds, weights, feat_pe)
+    torch.cuda.synchronize()
+    mem_after_pconv = torch.cuda.memory_allocated()
+
+    out_unfused = linear_layer(pconv_out)
+    torch.cuda.synchronize()
+    mem_after_linear = torch.cuda.memory_allocated()
+
+    # Backward
+    out_unfused.backward(grad_output)
+    torch.cuda.synchronize()
+    unfused_peak = torch.cuda.max_memory_allocated()
+
+    print(f"\nUnfused Memory Usage (MB):")
+    print(f"  PConv allocation: {(mem_after_pconv - mem_before) / 1024**2:.2f}")
+    print(f"  Total forward allocation: {(mem_after_linear - mem_before) / 1024**2:.2f}")
+    print(f"  Peak memory: {unfused_peak / 1024**2:.2f}")
+    print(f"  Additional memory for backward: {(unfused_peak - mem_after_linear) / 1024**2:.2f}")
+
+    feats_x.grad = None
+    weights.grad = None
+    feat_pe.grad = None
+    linear_layer.weight.grad = None
+    linear_layer.bias.grad = None
+    torch.cuda.empty_cache()
+
+    def test_memory_usage(model, name, inverse_neighbors=None, inverse_k=None, inverse_idx=None):
+        torch.cuda.reset_peak_memory_stats()
+        torch.cuda.synchronize()
+        mem_before = torch.cuda.memory_allocated()
+
+        # Forward
+        if inverse_neighbors is not None:
+            out = model(feats_x, nei_inds, inverse_neighbors, inverse_k, inverse_idx, weights, feat_pe)
+        else:
+            out = model(feats_x, nei_inds, weights, feat_pe)
+        torch.cuda.synchronize()
+        mem_after_forward = torch.cuda.memory_allocated()
+
+        # Backward
+        out.backward(grad_output)
+        torch.cuda.synchronize()
+        mem_peak = torch.cuda.max_memory_allocated()
+
+        print(f"\n{name} Memory Usage (MB):")
+        print(f"  Forward allocation: {(mem_after_forward - mem_before) / 1024**2:.2f}")
+        print(f"  Peak memory: {mem_peak / 1024**2:.2f}")
+        print(f"  Additional memory for backward: {(mem_peak - mem_after_forward) / 1024**2:.2f}")
+
+        feats_x.grad = None
+        weights.grad = None
+        feat_pe.grad = None
+        model.linear.weight.grad = None
+        model.linear.bias.grad = None
+        torch.cuda.empty_cache()
+
+        return mem_peak
+
+    reg_peak = test_memory_usage(pconv_linear, "Regular Fused")
+    opt_peak = test_memory_usage(pconv_linear_opt, "Optimized Fused", inverse_neighbors, inverse_k, inverse_idx)
+
+    print("\n---------- Memory Reduction ----------")
+    print(f"Unfused vs Regular Fused: {(unfused_peak - reg_peak) / 1024**2:.2f} MB ({100 * (1 - reg_peak/unfused_peak):.2f}%)")
+    print(f"Unfused vs Optimized Fused: {(unfused_peak - opt_peak) / 1024**2:.2f} MB ({100 * (1 - opt_peak/unfused_peak):.2f}%)")
+    print(f"Regular Fused vs Optimized Fused: {(reg_peak - opt_peak) / 1024**2:.2f} MB ({100 * (1 - opt_peak/reg_peak):.2f}%)")
+
+    print("\nTensor Shapes:")
+    print(f"  Input features: {feats_x.shape}")
+    print(f"  Neighbor indices: {nei_inds.shape}")
+    print(f"  Weights: {weights.shape}")
+    print(f"  Additional features: {feat_pe.shape}")
+    print(f"  Linear weights: {linear_weights.shape}")
+
+
 if __name__ == "__main__":
     test_pconv_linear()
     test_pconv_linear_with_memory()
@@ -1451,6 +2067,16 @@ if __name__ == "__main__":
 
     test_pconv_linear_opt()
     results = test_pconv_linear_opt_random(
+                    point_sizes=[25000, 50000, 100000, 200000],
+                    K=64,
+                    num_runs=3
+    )
+    plot_pconv_linear_opt_benchmark(results)
+
+    test_cutlass_vs_cuda_kernel()
+    test_pconv_linear_cutlass()
+
+    results = test_pconv_linear_cutlass_random(
                     point_sizes=[25000, 50000, 100000, 200000],
                     K=64,
                     num_runs=3

--- a/cpp_wrappers/cpp_pcf_kernel/test_kernels.py
+++ b/cpp_wrappers/cpp_pcf_kernel/test_kernels.py
@@ -78,52 +78,266 @@ import torch.cuda.profiler as profiler
 #             linear_bias)
 
 
+# path = "/nfs/stak/users/sivakuml/hpc-memory/cutlass/data/500000pts"
+# feats_x = torch.load(f"{path}/feat_x.pt").to(device=torch.device("cuda")).contiguous()
+# nei_inds = torch.load(f"{path}/nei_inds.pt").to(device=torch.device("cuda")).contiguous()
+# weights = torch.load(f"{path}/weights.pt").to(device=torch.device("cuda")).contiguous()
+# feat_pe = torch.load(f"{path}/feat_pe.pt").to(device=torch.device("cuda")).contiguous()
+# linear_weights = torch.load(f"{path}/linear_weights.pt").to(device=torch.device("cuda")).contiguous()
+# linear_bias = torch.load(f"{path}/linear_bias.pt").to(device=torch.device("cuda")).contiguous()
 
-feats_x = torch.load("data/feat_x.pt").to(device=torch.device("cuda")).contiguous()
-nei_inds = torch.load("data/nei_inds.pt").to(device=torch.device("cuda")).contiguous()
-weights = torch.load("data/weights.pt").to(device=torch.device("cuda")).contiguous()
-feat_pe = torch.load("data/feat_pe.pt").to(device=torch.device("cuda")).contiguous()
-linear_weights = torch.load("data/linear_weights.pt").to(device=torch.device("cuda"))
-linear_bias = torch.load("data/linear_bias.pt").to(device=torch.device("cuda"))
+# out_channel = 64
+# last_ch = 16
+# weightnet_dim = 16
+# linear_layer = torch.nn.Linear((out_channel // 4 + last_ch) * weightnet_dim, out_channel // 2).to(device=torch.device("cuda"))
+# linear_layer.weight.data.copy_(linear_weights)
+# linear_layer.bias.data.copy_(linear_bias)
 
-out_channel = 64
-last_ch = 16
-weightnet_dim = 16
-linear_layer = torch.nn.Linear((out_channel // 4 + last_ch) * weightnet_dim, out_channel // 2).to(device=torch.device("cuda"))
-linear_layer.weight.data.copy_(linear_weights)
-linear_layer.bias.data.copy_(linear_bias)
+# torch.cuda.synchronize()
 
-torch.cuda.synchronize()
+# print("input: ", feats_x.shape)
+# print("neighbor_inds: ", nei_inds.shape)
+# print("weights: ", weights.shape)
+# print("additional_features: ", feat_pe.shape)
+# print("linear_weights: ", linear_weights.shape)
+# print("linear_bias: ", linear_bias.shape)
 
-num_runs = 100
-total_time = 0
-for num_run in range(num_runs):
-    start = time.time()
-    output = pcf_cuda.pconv_forward(feats_x, nei_inds, weights, feat_pe)
-    output = linear_layer(output)
-    total_time += (time.time() - start)
+# num_runs = 100
+# total_time = 0
+# for num_run in range(num_runs):
+#     start = time.time()
+#     output = pcf_cuda.pconv_forward(feats_x, nei_inds, weights, feat_pe)
+#     output = linear_layer(output)
+#     torch.cuda.synchronize()
+#     total_time += (time.time() - start)
 
-average_time = (total_time / num_runs) * 1000
-print(f"Average Time: {average_time} ms")
+# average_time = (total_time / num_runs) * 1000
+# print(f"(Unfused) Average Time: {average_time} ms")
+
+# torch.cuda.synchronize()
+
+# total_time = 0
+# for num_run in range(num_runs):
+#     start = time.time()
+#     output = pcf_cuda.pconv_linear_forward(feats_x, nei_inds, weights, feat_pe, linear_weights, linear_bias)
+#     torch.cuda.synchronize()
+#     total_time += (time.time() - start)
+
+# average_time = (total_time / num_runs) * 1000
+# print(f"(Fused) PConv + Linear -> Average Time: {average_time} ms")
 
 
-total_time = 0
-for num_run in range(num_runs):
-    start = time.time()
-    output = pcf_cuda.pconv_linear_forward(feats_x, nei_inds, weights, feat_pe, linear_weights, linear_bias)
-    total_time += (time.time() - start)
 
-average_time = (total_time / num_runs) * 1000
-print(f"(Fused) PConv + Linear -> Average Time: {average_time} ms")
+# # ############
+# # # Check Equal
+# # ############
+# out_1 = pcf_cuda.pconv_forward(feats_x, nei_inds, weights, feat_pe)
+# out_1 = linear_layer(out_1)
+# torch.cuda.synchronize()
+# print(out_1)
 
+# out_2 = pcf_cuda.pconv_linear_forward(feats_x, nei_inds, weights, feat_pe, linear_weights, linear_bias)
+# torch.cuda.synchronize()
+# print(out_2)
+
+# # print(out_2.shape)
+# print(f"Two Tensors are Equal? {torch.allclose(out_1, out_2, atol=1e-5, rtol=1e-5)}")
 
 
 #############
-# Check Equal
+# Profile
 #############
-out_1 = pcf_cuda.pconv_forward(feats_x, nei_inds, weights, feat_pe)
-out_1 = linear_layer(out_1)
+# with torch.autograd.profiler.emit_nvtx():
+#     profiler.start()
+#     out_1 = pcf_cuda.pconv_forward(feats_x, nei_inds, weights, feat_pe)
+#     out_1 = linear_layer(out_1)
+#     # out_2 = pcf_cuda.pconv_linear_forward(feats_x, nei_inds, weights, feat_pe, linear_weights, linear_bias)
+#     profiler.stop()
 
-out_2 = pcf_cuda.pconv_linear_forward(feats_x, nei_inds, weights, feat_pe, linear_weights, linear_bias)
 
-print(f"Two Tensors are Equal? {torch.allclose(out_1, out_2, atol=1e-5, rtol=1e-5)}")
+
+class PConvFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, input_feat, neighbor_inds, weightnet, additional_features):
+        neighbor_inds.requires_grad = False
+        output = pcf_cuda.pconv_forward(input_feat, neighbor_inds, weightnet, additional_features)
+        ctx.save_for_backward(input_feat, neighbor_inds, weightnet, additional_features)
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        grad_input, grad_weight, grad_additional = pcf_cuda.pconv_backward(
+            grad_output.contiguous(), *ctx.saved_tensors)
+        return grad_input, None, grad_weight, grad_additional
+
+class PConvLinearFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, input_feat, neighbor_inds, weightnet, additional_features, linear_weights, linear_bias):
+        neighbor_inds.requires_grad = False
+        # Store pconv output for backward (have to change this so that fused kernel returns the pconv output too)
+        pconv_output = pcf_cuda.pconv_forward(input_feat, neighbor_inds, weightnet, additional_features)
+        output = pcf_cuda.pconv_linear_forward(input_feat, neighbor_inds, weightnet, additional_features, 
+                                             linear_weights, linear_bias)
+        
+        ctx.save_for_backward(input_feat, neighbor_inds, weightnet, additional_features, 
+                            linear_weights, pconv_output)
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        saved = ctx.saved_tensors
+        input_feat, neighbor_inds, weightnet, additional_features, linear_weights, pconv_output = saved
+        
+        grads = pcf_cuda.pconv_linear_backward(
+            grad_output.contiguous(), input_feat, neighbor_inds, weightnet,
+            additional_features, linear_weights, pconv_output)
+        
+        return grads[0], None, grads[1], grads[2], grads[3], grads[4]
+
+class PConv(torch.nn.Module):
+    def __init__(self):
+        super(PConv, self).__init__()
+
+    @staticmethod
+    def forward(input_features, neighbor_inds, weightnet, additional_features=None):
+        if additional_features is None:
+            additional_features = torch.zeros(input_features.shape[0], input_features.shape[1], 
+                                           neighbor_inds.shape[2], 0, device=input_features.device)
+        return PConvFunction.apply(input_features, neighbor_inds, weightnet, additional_features)
+
+class PConvLinear(torch.nn.Module):
+    def __init__(self, in_features, out_features):
+        super(PConvLinear, self).__init__()
+        self.linear = torch.nn.Linear(in_features, out_features)
+
+    def forward(self, input_features, neighbor_inds, weightnet, additional_features=None):
+        if additional_features is None:
+            additional_features = torch.zeros(input_features.shape[0], input_features.shape[1], 
+                                           neighbor_inds.shape[2], 0, device=input_features.device)
+        return PConvLinearFunction.apply(input_features, neighbor_inds, weightnet, additional_features,
+                                       self.linear.weight, self.linear.bias)
+
+
+def test_pconv_linear():
+    path = "/nfs/stak/users/sivakuml/hpc-memory/cutlass/data/500000pts"
+    device = torch.device("cuda")
+    
+    feats_x = torch.load(f"{path}/feat_x.pt").to(device).contiguous()
+    nei_inds = torch.load(f"{path}/nei_inds.pt").to(device).contiguous()
+    weights = torch.load(f"{path}/weights.pt").to(device).contiguous()
+    feat_pe = torch.load(f"{path}/feat_pe.pt").to(device).contiguous()
+    linear_weights = torch.load(f"{path}/linear_weights.pt").to(device).contiguous()
+    linear_bias = torch.load(f"{path}/linear_bias.pt").to(device).contiguous()
+
+    # Params
+    out_channel = 64
+    last_ch = 16
+    weightnet_dim = 16
+
+    pconv = PConv()
+    linear_layer = torch.nn.Linear((out_channel // 4 + last_ch) * weightnet_dim, out_channel // 2).to(device)
+    linear_layer.weight.data.copy_(linear_weights)
+    linear_layer.bias.data.copy_(linear_bias)
+
+    pconv_linear = PConvLinear((out_channel // 4 + last_ch) * weightnet_dim, out_channel // 2)
+    pconv_linear.linear.weight.data.copy_(linear_weights)
+    pconv_linear.linear.bias.data.copy_(linear_bias)
+    pconv_linear = pconv_linear.cuda()
+
+    # Create dummy gradient for backward pass
+    grad_output = torch.randn_like(linear_layer(torch.empty(feats_x.shape[0], feats_x.shape[1], 
+                                              (out_channel // 4 + last_ch) * weightnet_dim, device=device)))
+
+    # Forward & Backward (Unfused)
+    pconv_out = pconv(feats_x, nei_inds, weights, feat_pe)
+    out_unfused = linear_layer(pconv_out)
+    out_unfused.backward(grad_output)
+
+    # Store unfused gradients
+    unfused_grads = {
+        "input": feats_x.grad.clone(),
+        "weightnet": weights.grad.clone(),
+        "additional": feat_pe.grad.clone(),
+        "linear_weight": linear_layer.weight.grad.clone(),
+        "linear_bias": linear_layer.bias.grad.clone()
+    }
+
+    # Clear gradients
+    feats_x.grad = None
+    weights.grad = None
+    feat_pe.grad = None
+    linear_layer.weight.grad = None
+    linear_layer.bias.grad = None
+
+    # Forward & Backward (Fused)
+    out_fused = pconv_linear(feats_x, nei_inds, weights, feat_pe)
+    out_fused.backward(grad_output)
+
+    # torch.cuda.synchronize()
+
+    # Store fused gradients
+    fused_grads = {
+        "input": feats_x.grad.clone(),
+        "weightnet": weights.grad.clone(),
+        "additional": feat_pe.grad.clone(),
+        "linear_weight": pconv_linear.linear.weight.grad.clone(),
+        "linear_bias": pconv_linear.linear.bias.grad.clone()
+    }
+    
+    # Compare outputs
+    print("\nForward output max difference:", 
+          torch.max(torch.abs(out_unfused - out_fused)).item())
+    
+    # Compare gradients
+    print("\nGradient differences (max absolute error):")
+    for key in unfused_grads:
+        diff = torch.max(torch.abs(unfused_grads[key] - fused_grads[key])).item()
+        print(f"{key:13} grad diff: {diff:.6f}")
+        print(f"{key:13} stats:")
+        print(f"  Unfused - min: {unfused_grads[key].min().item():.6f}, max: {unfused_grads[key].max().item():.6f}, mean: {unfused_grads[key].mean().item():.6f}")
+        print(f"  Fused   - min: {fused_grads[key].min().item():.6f}, max: {fused_grads[key].max().item():.6f}, mean: {fused_grads[key].mean().item():.6f}")
+        print()
+    
+    # Timing comparison
+    num_runs = 100
+    torch.cuda.synchronize()
+    
+    # Time unfused
+    total_time = 0
+    for _ in range(num_runs):
+        pconv_out = pconv(feats_x, nei_inds, weights, feat_pe)
+        out_unfused = linear_layer(pconv_out)
+        
+        feats_x.grad = None
+        weights.grad = None
+        feat_pe.grad = None
+        linear_layer.weight.grad = None
+        linear_layer.bias.grad = None
+        
+        torch.cuda.synchronize()
+        start = time.time()
+        out_unfused.backward(grad_output, retain_graph=True)
+        torch.cuda.synchronize()
+        total_time += (time.time() - start)
+    print(f"\n(Unfused) Average Time: {(total_time / num_runs) * 1000} ms")
+    
+    # Time fused
+    total_time = 0
+    for _ in range(num_runs):
+        out_fused = pconv_linear(feats_x, nei_inds, weights, feat_pe)
+        
+        feats_x.grad = None
+        weights.grad = None
+        feat_pe.grad = None
+        pconv_linear.linear.weight.grad = None
+        pconv_linear.linear.bias.grad = None
+        
+        torch.cuda.synchronize()
+        start = time.time()
+        out_fused.backward(grad_output, retain_graph=True)
+        torch.cuda.synchronize()
+        total_time += (time.time() - start)
+    print(f"(Fused) Average Time: {(total_time / num_runs) * 1000} ms")
+
+
+test_pconv_linear()

--- a/cpp_wrappers/cpp_pcf_kernel/test_kernels.py
+++ b/cpp_wrappers/cpp_pcf_kernel/test_kernels.py
@@ -1,4 +1,5 @@
 import time
+import matplotlib.pyplot as plt
 import numpy as np
 import torch
 import pcf_cuda
@@ -108,6 +109,28 @@ class PConvLinearOpt(torch.nn.Module):
                                           neighbor_inds.shape[2], 0, device=input_features.device)
         return PConvLinearOptFunction.apply(input_features, neighbor_inds, weightnet, additional_features,
                                          self.linear.weight, self.linear.bias)
+
+
+def knn(pts1, pts2, k):
+    """
+    Find the k-nearest neighbors for each point in pts1 from pts2
+
+    Args:
+        pts1: (B, S, C) tensor of query points
+        pts2: (B, N, C) tensor of reference points
+        k: int, number of neighbors to find
+
+    Returns:
+        (B, S, k) tensor of neighbor indices
+    """
+    B, S, C = pts1.shape
+    _, N, _ = pts2.shape
+    x_i = LazyTensor(pts1.view(B, S, 1, C))
+    y_j = LazyTensor(pts2.view(B, 1, N, C))
+    D_ij = ((x_i - y_j)**2).sum(-1)**0.5
+    _, indices_i = D_ij.Kmin_argKmin(k, dim=2)
+    return indices_i.long()
+
 
 def test_pconv_linear():
     path = "/nfs/stak/users/sivakuml/hpc-memory/cutlass/data/500000pts"
@@ -373,10 +396,12 @@ def test_knn_inv():
     def create_inverse_python(neighbor_mat, total_points):
         """
         Create inverse mapping for KNN
+
         Args:
-            neighbor_mat: Array of shape [num_points, K] containing neighbor indices
+            neighbor_mat: shape [num_points, K] containing neighbor indices
             total_points: Total number of points in the point cloud (including potential points to add)
         """
+
         K = neighbor_mat.shape[1]
         neigh = [[] for n in range(total_points)]
         inv_k = [[] for n in range(total_points)]
@@ -405,15 +430,6 @@ def test_knn_inv():
         return (torch.from_numpy(neighbors).cuda().long(), 
                 torch.from_numpy(inv_k).cuda().long(), 
                 torch.from_numpy(np.array(idx_array)).cuda().long())
-
-    def knn(pts1, pts2, nsample):
-        B, S, C = pts1.shape
-        _, N, _ = pts2.shape
-        x_i = LazyTensor(pts1.view(B, S, 1, C))
-        y_j = LazyTensor(pts2.view(B, 1, N, C))
-        D_ij = ((x_i - y_j)**2).sum(-1)**0.5
-        _, indices_i = D_ij.Kmin_argKmin(nsample, dim=2)
-        return indices_i.long()
 
     def compare_outputs_by_segments(cuda_neighbors, cuda_k, py_neighbors, py_k, inv_idx):
         """
@@ -453,12 +469,12 @@ def test_knn_inv():
         return total_diff
 
 
-    B = 4          # batch size (meh!!)
-    N = 200000        # number of points 
-    C_in = 3        # number of inp channels
-    K = 64         # number of neighbors
+    B = 1               # batch size (meh!!)
+    N = 200000          # number of points 
+    C_in = 16           # number of inp channels
+    K = 64              # number of neighbors
     total_points = N
-    num_runs = 100
+    num_runs = 3
 
     torch.manual_seed(42)
     input_points = torch.randn(B, N, 3, device="cuda", requires_grad=False)
@@ -889,8 +905,333 @@ def test_pconv_linear_opt():
     print(f"  Linear weights: {linear_weights.shape}")
 
 
+def test_pconv_linear_opt_random(point_sizes=[50000, 100000, 200000], K=64, num_runs=5):
+    """
+    Test PConv + Linear optimization with random data
+
+    Args:
+        point_sizes: Number of points
+        K: Number of neighbors
+        num_runs: Number of runs for each point size
+
+    Returns:
+        Dict of results
+    """
+
+    device = torch.device("cuda")
+    torch.manual_seed(42)
+    
+    # Params
+    B = 1           # batch size
+    C_in = 16       # input feature channels 
+    C_add = 16      # additional feature channels
+    C_mid = 16      # mid feature channels - weight dim
+    C_out = 64      # output channels for linear layer
+
+    results = {
+        'point_sizes': point_sizes,
+        'unfused': {'forward': [], 'backward': [], 'total': [], 'memory': []},
+        'fused': {'forward': [], 'backward': [], 'total': [], 'memory': []},
+        'opt_fused': {'forward': [], 'backward': [], 'total': [], 'memory': []}
+    }
+
+    for n_points in point_sizes:
+        print(f"\n\n===== Testing with {n_points} points =====")
+
+        input_points = torch.randn(B, n_points, 3, device=device, requires_grad=True)
+        input_features = torch.randn(B, n_points, C_in, device=device, requires_grad=True)
+
+        print("Calculating KNN indices...")
+        neighbor_inds = knn(input_points, input_points, K).contiguous()
+        print(f"KNN indices shape: {neighbor_inds.shape}")
+
+        weights = torch.randn(B, n_points, K, C_mid, device=device, requires_grad=True)
+        additional_features = torch.randn(B, n_points, K, C_add, device=device, requires_grad=True)
+        linear_weights = torch.randn(C_out, (C_in + C_add) * C_mid, device=device, requires_grad=True)
+        linear_bias = torch.randn(C_out, device=device, requires_grad=True)
+
+        # Init
+        pconv = PConv()
+        linear_layer = torch.nn.Linear((C_in + C_add) * C_mid, C_out).to(device)
+        linear_layer.weight.data.copy_(linear_weights)
+        linear_layer.bias.data.copy_(linear_bias)
+
+        pconv_linear = PConvLinear((C_in + C_add) * C_mid, C_out)
+        pconv_linear.linear.weight.data.copy_(linear_weights)
+        pconv_linear.linear.bias.data.copy_(linear_bias)
+        pconv_linear = pconv_linear.cuda()
+
+        pconv_linear_opt = PConvLinearOpt((C_in + C_add) * C_mid, C_out)
+        pconv_linear_opt.linear.weight.data.copy_(linear_weights)
+        pconv_linear_opt.linear.bias.data.copy_(linear_bias)
+        pconv_linear_opt = pconv_linear_opt.cuda()
+
+        # Dummy gradient for backward pass
+        grad_output = torch.randn(B, n_points, C_out, device=device)
+
+        print("Performing warm-up runs...")
+        for _ in range(2):
+            # Unfused
+            pconv_out = pconv(input_features, neighbor_inds, weights, additional_features)
+            out_unfused = linear_layer(pconv_out)
+            out_unfused.backward(grad_output)
+
+            input_features.grad = None
+            weights.grad = None
+            additional_features.grad = None
+            linear_layer.weight.grad = None
+            linear_layer.bias.grad = None
+
+            # Fused
+            out_fused = pconv_linear(input_features, neighbor_inds, weights, additional_features)
+            out_fused.backward(grad_output)
+
+            input_features.grad = None
+            weights.grad = None
+            additional_features.grad = None
+            pconv_linear.linear.weight.grad = None
+            pconv_linear.linear.bias.grad = None
+
+            # Optimized fused
+            out_opt_fused = pconv_linear_opt(input_features, neighbor_inds, weights, additional_features)
+            out_opt_fused.backward(grad_output)
+
+            input_features.grad = None
+            weights.grad = None
+            additional_features.grad = None
+            pconv_linear_opt.linear.weight.grad = None
+            pconv_linear_opt.linear.bias.grad = None
+
+
+        unfused_times = {'forward': [], 'backward': [], 'memory': []}
+        fused_times = {'forward': [], 'backward': [], 'memory': []}
+        opt_fused_times = {'forward': [], 'backward': [], 'memory': []}
+
+        print(f"Running benchmark with {num_runs} iterations for each implementation...")
+        for r in range(num_runs):
+            print(f"Run {r+1}/{num_runs}")
+
+            # ----- Unfused -----
+            torch.cuda.reset_peak_memory_stats()
+            torch.cuda.synchronize()
+            mem_before = torch.cuda.memory_allocated()
+
+            # Forward
+            torch.cuda.synchronize()
+            start = time.time()
+            pconv_out = pconv(input_features, neighbor_inds, weights, additional_features)
+            out_unfused = linear_layer(pconv_out)
+            torch.cuda.synchronize()
+            forward_time = time.time() - start
+
+            # Backward
+            input_features.grad = None
+            weights.grad = None
+            additional_features.grad = None
+            linear_layer.weight.grad = None
+            linear_layer.bias.grad = None
+
+            torch.cuda.synchronize()
+            start = time.time()
+            out_unfused.backward(grad_output)
+            torch.cuda.synchronize()
+            backward_time = time.time() - start
+
+            memory_used = torch.cuda.max_memory_allocated() - mem_before
+
+            unfused_times['forward'].append(forward_time * 1000)        # ms
+            unfused_times['backward'].append(backward_time * 1000)      # ms
+            unfused_times['memory'].append(memory_used / (1024 ** 2))   # MB
+
+            # ----- Fused -----
+            torch.cuda.reset_peak_memory_stats()
+            torch.cuda.synchronize()
+            mem_before = torch.cuda.memory_allocated()
+
+            # Forward
+            torch.cuda.synchronize()
+            start = time.time()
+            out_fused = pconv_linear(input_features, neighbor_inds, weights, additional_features)
+            torch.cuda.synchronize()
+            forward_time = time.time() - start
+
+            # Backward
+            input_features.grad = None
+            weights.grad = None
+            additional_features.grad = None
+            pconv_linear.linear.weight.grad = None
+            pconv_linear.linear.bias.grad = None
+
+            torch.cuda.synchronize()
+            start = time.time()
+            out_fused.backward(grad_output)
+            torch.cuda.synchronize()
+            backward_time = time.time() - start
+
+            memory_used = torch.cuda.max_memory_allocated() - mem_before
+
+            fused_times['forward'].append(forward_time * 1000)          # ms
+            fused_times['backward'].append(backward_time * 1000)        # ms
+            fused_times['memory'].append(memory_used / (1024 ** 2))     # MB
+
+            # ----- Optimized Fused -----
+            torch.cuda.reset_peak_memory_stats()
+            torch.cuda.synchronize()
+            mem_before = torch.cuda.memory_allocated()
+
+            # Forward
+            torch.cuda.synchronize()
+            start = time.time()
+            out_opt_fused = pconv_linear_opt(input_features, neighbor_inds, weights, additional_features)
+            torch.cuda.synchronize()
+            forward_time = time.time() - start
+
+            # Backward
+            input_features.grad = None
+            weights.grad = None
+            additional_features.grad = None
+            pconv_linear_opt.linear.weight.grad = None
+            pconv_linear_opt.linear.bias.grad = None
+
+            torch.cuda.synchronize()
+            start = time.time()
+            out_opt_fused.backward(grad_output)
+            torch.cuda.synchronize()
+            backward_time = time.time() - start
+
+            memory_used = torch.cuda.max_memory_allocated() - mem_before
+
+            opt_fused_times['forward'].append(forward_time * 1000)          # ms
+            opt_fused_times['backward'].append(backward_time * 1000)        # ms
+            opt_fused_times['memory'].append(memory_used / (1024 ** 2))     # MB
+
+
+        for impl, times in [('unfused', unfused_times), 
+                            ('fused', fused_times), 
+                            ('opt_fused', opt_fused_times)]:
+            results[impl]['forward'].append(np.mean(times['forward']))
+            results[impl]['backward'].append(np.mean(times['backward']))
+            results[impl]['total'].append(np.mean(times['forward']) + np.mean(times['backward']))
+            results[impl]['memory'].append(np.mean(times['memory']))
+
+            print(f"\n{impl.upper()} results for {n_points} points:")
+            print(f"  Forward time: {np.mean(times['forward']):.2f} ± {np.std(times['forward']):.2f} ms")
+            print(f"  Backward time: {np.mean(times['backward']):.2f} ± {np.std(times['backward']):.2f} ms")
+            print(f"  Total time: {np.mean(times['forward']) + np.mean(times['backward']):.2f} ms")
+            print(f"  Memory usage: {np.mean(times['memory']):.2f} ± {np.std(times['memory']):.2f} MB")
+
+    return results
+
+
+def plot_benchmark_results(results):
+    """
+    Plot benchmark results
+
+    Args:
+        results: Dict of results from test_pconv_linear_opt_random
+    """
+    point_sizes = results['point_sizes']
+
+    plt.figure(figsize=(20, 12))
+
+    # forward times
+    plt.subplot(2, 2, 1)
+    plt.plot(point_sizes, results['unfused']['forward'], 'o-', label='Unfused')
+    plt.plot(point_sizes, results['fused']['forward'], 's-', label='Fused')
+    plt.plot(point_sizes, results['opt_fused']['forward'], '^-', label='Optimized Fused')
+    plt.title('Forward Time')
+    plt.xlabel('Number of Points')
+    plt.ylabel('Time (ms)')
+    plt.grid(True)
+    plt.legend()
+
+    # backward times
+    plt.subplot(2, 2, 2)
+    plt.plot(point_sizes, results['unfused']['backward'], 'o-', label='Unfused')
+    plt.plot(point_sizes, results['fused']['backward'], 's-', label='Fused')
+    plt.plot(point_sizes, results['opt_fused']['backward'], '^-', label='Optimized Fused')
+    plt.title('Backward Time')
+    plt.xlabel('Number of Points')
+    plt.ylabel('Time (ms)')
+    plt.grid(True)
+    plt.legend()
+
+    # total times
+    plt.subplot(2, 2, 3)
+    plt.plot(point_sizes, results['unfused']['total'], 'o-', label='Unfused')
+    plt.plot(point_sizes, results['fused']['total'], 's-', label='Fused')
+    plt.plot(point_sizes, results['opt_fused']['total'], '^-', label='Optimized Fused')
+    plt.title('Total Time (Forward + Backward)')
+    plt.xlabel('Number of Points')
+    plt.ylabel('Time (ms)')
+    plt.grid(True)
+    plt.legend()
+
+    # memory usage
+    plt.subplot(2, 2, 4)
+    plt.plot(point_sizes, results['unfused']['memory'], 'o-', label='Unfused')
+    plt.plot(point_sizes, results['fused']['memory'], 's-', label='Fused')
+    plt.plot(point_sizes, results['opt_fused']['memory'], '^-', label='Optimized Fused')
+    plt.title('Memory Usage')
+    plt.xlabel('Number of Points')
+    plt.ylabel('Memory (MB)')
+    plt.grid(True)
+    plt.legend()
+
+    plt.tight_layout()
+    plt.savefig('pconv_benchmark_results.png', dpi=300)
+    plt.show()
+
+    plt.figure(figsize=(20, 6))
+
+    # Speedup relative to unfused
+    plt.subplot(1, 2, 1)
+    plt.plot(point_sizes, 
+             [u/f for u, f in zip(results['unfused']['total'], results['fused']['total'])], 
+             's-', label='Fused vs Unfused')
+    plt.plot(point_sizes, 
+             [u/o for u, o in zip(results['unfused']['total'], results['opt_fused']['total'])], 
+             '^-', label='Optimized Fused vs Unfused')
+    plt.plot(point_sizes, 
+             [f/o for f, o in zip(results['fused']['total'], results['opt_fused']['total'])], 
+             'D-', label='Optimized Fused vs Fused')
+    plt.title('Speedup Factor')
+    plt.xlabel('Number of Points')
+    plt.ylabel('Speedup (higher is better)')
+    plt.grid(True)
+    plt.legend()
+
+    # Memory savings relative to unfused
+    plt.subplot(1, 2, 2)
+    plt.plot(point_sizes, 
+             [u/f for u, f in zip(results['unfused']['memory'], results['fused']['memory'])], 
+             's-', label='Fused vs Unfused')
+    plt.plot(point_sizes, 
+             [u/o for u, o in zip(results['unfused']['memory'], results['opt_fused']['memory'])], 
+             '^-', label='Optimized Fused vs Unfused')
+    plt.plot(point_sizes, 
+             [f/o for f, o in zip(results['fused']['memory'], results['opt_fused']['memory'])], 
+             'D-', label='Optimized Fused vs Fused')
+    plt.title('Memory Reduction Factor')
+    plt.xlabel('Number of Points')
+    plt.ylabel('Memory Reduction (higher is better)')
+    plt.grid(True)
+    plt.legend()
+
+    plt.tight_layout()
+    plt.savefig('pconv_benchmark_speedup.png', dpi=300)
+    plt.show()
+
+
 if __name__ == "__main__":
-    # test_pconv_linear()
-    # test_pconv_linear_with_memory()
-    # test_knn_inv()
+    test_pconv_linear()
+    test_pconv_linear_with_memory()
+    test_knn_inv()
     test_pconv_linear_opt()
+
+    results = test_pconv_linear_opt_random(
+        point_sizes=[50000, 100000, 200000],
+        K=64,
+        num_runs=3
+    )
+    plot_benchmark_results(results)

--- a/cpp_wrappers/cpp_pcf_kernel/test_kernels.py
+++ b/cpp_wrappers/cpp_pcf_kernel/test_kernels.py
@@ -4,158 +4,6 @@ import pcf_cuda
 import torch.cuda.profiler as profiler
 
 
-# class PConvFunction(torch.autograd.Function):
-#     @staticmethod
-#     def forward(
-#             ctx,
-#             input_feat,
-#             neighbor_inds,
-#             weightnet,
-#             additional_features):
-#         neighbor_inds.requires_grad = False
-#         output = pcf_cuda.pconv_forward(
-#             input_feat, neighbor_inds, weightnet, additional_features)
-#         return output
-
-#     @staticmethod
-#     def backward(ctx, grad_output):
-#         grad_input, grad_weight, grad_additional = pcf_cuda.pconv_backward(
-#             grad_output.contiguous(), *ctx.saved_tensors)
-#         return grad_input, None, grad_weight, grad_additional
-
-
-# class PConv(torch.nn.Module):
-#     def __init__(self):
-#         super(PConv, self).__init__()
-
-#     @staticmethod
-#     def forward(input_features, neighbor_inds, weightnet, additional_features=None):
-#         if additional_features is None:
-#             additional_features = torch.zeros(input_features.shape[0], input_features.shape[1], neighbor_inds.shape[2], 0)
-#         return PConvFunction.apply(
-#             input_features,
-#             neighbor_inds,
-#             weightnet,
-#             additional_features)
-
-
-# class PConvFunction(torch.autograd.Function):
-#     @staticmethod
-#     def forward(
-#             ctx,
-#             input_feat,
-#             neighbor_inds,
-#             weightnet,
-#             additional_features,
-#             linear_weights,
-#             linear_bias):
-#         neighbor_inds.requires_grad = False
-#         output = pcf_cuda.pconv_forward(
-#             input_feat, neighbor_inds, weightnet, additional_features, linear_weights, linear_bias)
-#         return output
-
-#     @staticmethod
-#     def backward(ctx, grad_output):
-#         grad_input, grad_weight, grad_additional = pcf_cuda.pconv_backward(
-#             grad_output.contiguous(), *ctx.saved_tensors)
-#         return grad_input, None, grad_weight, grad_additional
-
-
-# class PConv(torch.nn.Module):
-#     def __init__(self):
-#         super(PConv, self).__init__()
-
-#     @staticmethod
-#     def forward(input_features, neighbor_inds, weightnet, linear_weights, linear_bias, additional_features=None):
-#         if additional_features is None:
-#             additional_features = torch.zeros(input_features.shape[0], input_features.shape[1], neighbor_inds.shape[2], 0)
-#         return PConvFunction.apply(
-#             input_features,
-#             neighbor_inds,
-#             weightnet,
-#             additional_features,
-#             linear_weights,
-#             linear_bias)
-
-
-# path = "/nfs/stak/users/sivakuml/hpc-memory/cutlass/data/500000pts"
-# feats_x = torch.load(f"{path}/feat_x.pt").to(device=torch.device("cuda")).contiguous()
-# nei_inds = torch.load(f"{path}/nei_inds.pt").to(device=torch.device("cuda")).contiguous()
-# weights = torch.load(f"{path}/weights.pt").to(device=torch.device("cuda")).contiguous()
-# feat_pe = torch.load(f"{path}/feat_pe.pt").to(device=torch.device("cuda")).contiguous()
-# linear_weights = torch.load(f"{path}/linear_weights.pt").to(device=torch.device("cuda")).contiguous()
-# linear_bias = torch.load(f"{path}/linear_bias.pt").to(device=torch.device("cuda")).contiguous()
-
-# out_channel = 64
-# last_ch = 16
-# weightnet_dim = 16
-# linear_layer = torch.nn.Linear((out_channel // 4 + last_ch) * weightnet_dim, out_channel // 2).to(device=torch.device("cuda"))
-# linear_layer.weight.data.copy_(linear_weights)
-# linear_layer.bias.data.copy_(linear_bias)
-
-# torch.cuda.synchronize()
-
-# print("input: ", feats_x.shape)
-# print("neighbor_inds: ", nei_inds.shape)
-# print("weights: ", weights.shape)
-# print("additional_features: ", feat_pe.shape)
-# print("linear_weights: ", linear_weights.shape)
-# print("linear_bias: ", linear_bias.shape)
-
-# num_runs = 100
-# total_time = 0
-# for num_run in range(num_runs):
-#     start = time.time()
-#     output = pcf_cuda.pconv_forward(feats_x, nei_inds, weights, feat_pe)
-#     output = linear_layer(output)
-#     torch.cuda.synchronize()
-#     total_time += (time.time() - start)
-
-# average_time = (total_time / num_runs) * 1000
-# print(f"(Unfused) Average Time: {average_time} ms")
-
-# torch.cuda.synchronize()
-
-# total_time = 0
-# for num_run in range(num_runs):
-#     start = time.time()
-#     output = pcf_cuda.pconv_linear_forward(feats_x, nei_inds, weights, feat_pe, linear_weights, linear_bias)
-#     torch.cuda.synchronize()
-#     total_time += (time.time() - start)
-
-# average_time = (total_time / num_runs) * 1000
-# print(f"(Fused) PConv + Linear -> Average Time: {average_time} ms")
-
-
-
-# # ############
-# # # Check Equal
-# # ############
-# out_1 = pcf_cuda.pconv_forward(feats_x, nei_inds, weights, feat_pe)
-# out_1 = linear_layer(out_1)
-# torch.cuda.synchronize()
-# print(out_1)
-
-# out_2 = pcf_cuda.pconv_linear_forward(feats_x, nei_inds, weights, feat_pe, linear_weights, linear_bias)
-# torch.cuda.synchronize()
-# print(out_2)
-
-# # print(out_2.shape)
-# print(f"Two Tensors are Equal? {torch.allclose(out_1, out_2, atol=1e-5, rtol=1e-5)}")
-
-
-#############
-# Profile
-#############
-# with torch.autograd.profiler.emit_nvtx():
-#     profiler.start()
-#     out_1 = pcf_cuda.pconv_forward(feats_x, nei_inds, weights, feat_pe)
-#     out_1 = linear_layer(out_1)
-#     # out_2 = pcf_cuda.pconv_linear_forward(feats_x, nei_inds, weights, feat_pe, linear_weights, linear_bias)
-#     profiler.stop()
-
-
-
 class PConvFunction(torch.autograd.Function):
     @staticmethod
     def forward(ctx, input_feat, neighbor_inds, weightnet, additional_features):
@@ -174,9 +22,7 @@ class PConvLinearFunction(torch.autograd.Function):
     @staticmethod
     def forward(ctx, input_feat, neighbor_inds, weightnet, additional_features, linear_weights, linear_bias):
         neighbor_inds.requires_grad = False
-        # Store pconv output for backward (have to change this so that fused kernel returns the pconv output too)
-        pconv_output = pcf_cuda.pconv_forward(input_feat, neighbor_inds, weightnet, additional_features)
-        output = pcf_cuda.pconv_linear_forward(input_feat, neighbor_inds, weightnet, additional_features, 
+        output, pconv_output = pcf_cuda.pconv_linear_forward(input_feat, neighbor_inds, weightnet, additional_features, 
                                              linear_weights, linear_bias)
         
         ctx.save_for_backward(input_feat, neighbor_inds, weightnet, additional_features, 
@@ -273,7 +119,7 @@ def test_pconv_linear():
     out_fused = pconv_linear(feats_x, nei_inds, weights, feat_pe)
     out_fused.backward(grad_output)
 
-    # torch.cuda.synchronize()
+    torch.cuda.synchronize()
 
     # Store fused gradients
     fused_grads = {
@@ -340,4 +186,144 @@ def test_pconv_linear():
     print(f"(Fused) Average Time: {(total_time / num_runs) * 1000} ms")
 
 
-test_pconv_linear()
+def test_pconv_linear_with_memory(num_runs=100):
+    path = "/nfs/stak/users/sivakuml/hpc-memory/cutlass/data/500000pts"
+    device = torch.device("cuda")
+
+    # Load data
+    feats_x = torch.load(f"{path}/feat_x.pt").to(device).contiguous()
+    nei_inds = torch.load(f"{path}/nei_inds.pt").to(device).contiguous()
+    weights = torch.load(f"{path}/weights.pt").to(device).contiguous()
+    feat_pe = torch.load(f"{path}/feat_pe.pt").to(device).contiguous()
+    linear_weights = torch.load(f"{path}/linear_weights.pt").to(device).contiguous()
+    linear_bias = torch.load(f"{path}/linear_bias.pt").to(device).contiguous()
+
+    # Params
+    out_channel = 64
+    last_ch = 16
+    weightnet_dim = 16
+
+    unfused_stats = {
+        'after_pconv': [],
+        'after_linear': [],
+        'peak_memory': []
+    }
+
+    fused_stats = {
+        'after_forward': [],
+        'peak_memory': []
+    }
+
+    # Initialize models
+    pconv = PConv()
+    linear_layer = torch.nn.Linear((out_channel // 4 + last_ch) * weightnet_dim, out_channel // 2).to(device)
+    linear_layer.weight.data.copy_(linear_weights)
+    linear_layer.bias.data.copy_(linear_bias)
+
+    pconv_linear = PConvLinear((out_channel // 4 + last_ch) * weightnet_dim, out_channel // 2)
+    pconv_linear.linear.weight.data.copy_(linear_weights)
+    pconv_linear.linear.bias.data.copy_(linear_bias)
+    pconv_linear = pconv_linear.cuda()
+
+    # Dummy gradient for backward pass
+    grad_output = torch.randn_like(linear_layer(torch.empty(feats_x.shape[0], feats_x.shape[1], 
+                                              (out_channel // 4 + last_ch) * weightnet_dim, device=device)))
+
+    print(f"\nRunning memory test for {num_runs} iterations...")
+
+    for i in range(num_runs):
+        if (i + 1) % 10 == 0:
+            print(f"Completed {i + 1} runs...")
+
+        # Test Unfused Version
+        torch.cuda.reset_peak_memory_stats()
+        torch.cuda.synchronize()
+        mem_before = torch.cuda.memory_allocated()
+
+        # Forward Pass (Unfused)
+        pconv_out = pconv(feats_x, nei_inds, weights, feat_pe)
+        torch.cuda.synchronize()
+        unfused_stats['after_pconv'].append(torch.cuda.memory_allocated() - mem_before)
+
+        out_unfused = linear_layer(pconv_out)
+        torch.cuda.synchronize()
+        unfused_stats['after_linear'].append(torch.cuda.memory_allocated() - mem_before)
+
+        # Backward Pass (Unfused)
+        out_unfused.backward(grad_output)
+        torch.cuda.synchronize()
+        unfused_stats['peak_memory'].append(torch.cuda.max_memory_allocated())
+
+        # Clear memory
+        del pconv_out, out_unfused
+        feats_x.grad = None
+        weights.grad = None
+        feat_pe.grad = None
+        linear_layer.weight.grad = None
+        linear_layer.bias.grad = None
+        torch.cuda.empty_cache()
+
+        # Test Fused Version
+        torch.cuda.reset_peak_memory_stats()
+        torch.cuda.synchronize()
+        mem_before = torch.cuda.memory_allocated()
+
+        # Forward & Backward (Fused)
+        out_fused = pconv_linear(feats_x, nei_inds, weights, feat_pe)
+        torch.cuda.synchronize()
+        fused_stats['after_forward'].append(torch.cuda.memory_allocated() - mem_before)
+
+        out_fused.backward(grad_output)
+        torch.cuda.synchronize()
+        fused_stats['peak_memory'].append(torch.cuda.max_memory_allocated())
+
+        # Clear memory
+        del out_fused
+        feats_x.grad = None
+        weights.grad = None
+        feat_pe.grad = None
+        pconv_linear.linear.weight.grad = None
+        pconv_linear.linear.bias.grad = None
+        torch.cuda.empty_cache()
+
+    def calculate_stats(values):
+        values = torch.tensor(values, dtype=torch.float64)
+        return {
+            'mean': values.mean().item(),
+            'std': values.std().item(),
+            'min': values.min().item(),
+            'max': values.max().item()
+        }
+
+    print("\nUnfused Version Statistics (in MB):")
+    for key, values in unfused_stats.items():
+        stats = calculate_stats(values)
+        print(f"\n{key}:")
+        print(f"  Mean: {stats['mean'] / 1024**2:.2f} ± {stats['std'] / 1024**2:.2f}")
+        print(f"  Min: {stats['min'] / 1024**2:.2f}")
+        print(f"  Max: {stats['max'] / 1024**2:.2f}")
+
+    print("\nFused Version Statistics (in MB):")
+    for key, values in fused_stats.items():
+        stats = calculate_stats(values)
+        print(f"\n{key}:")
+        print(f"  Mean: {stats['mean'] / 1024**2:.2f} ± {stats['std'] / 1024**2:.2f}")
+        print(f"  Min: {stats['min'] / 1024**2:.2f}")
+        print(f"  Max: {stats['max'] / 1024**2:.2f}")
+
+    # Calculate average memory savings
+    avg_memory_saved = (torch.tensor(unfused_stats['peak_memory'], dtype=torch.float64).mean() - 
+                       torch.tensor(fused_stats['peak_memory'], dtype=torch.float64).mean())
+    print(f"\nAverage Memory Saved by Fusion: {avg_memory_saved / 1024**2:.2f} MB")
+
+    print("\nTensor Sizes:")
+    print(f"Input features: {feats_x.shape}")
+    print(f"Neighbor indices: {nei_inds.shape}")
+    print(f"Weights: {weights.shape}")
+    print(f"Additional features: {feat_pe.shape}")
+    print(f"Linear weights: {linear_weights.shape}")
+
+
+if __name__ == "__main__":
+    test_pconv_linear()
+    test_pconv_linear_with_memory()

--- a/cpp_wrappers/cpp_pcf_kernel/test_kernels.py
+++ b/cpp_wrappers/cpp_pcf_kernel/test_kernels.py
@@ -1438,10 +1438,10 @@ def plot_pconv_linear_opt_benchmark(results):
 
 
 if __name__ == "__main__":
-    # test_pconv_linear()
-    # test_pconv_linear_with_memory()
+    test_pconv_linear()
+    test_pconv_linear_with_memory()
 
-    # test_knn_inv()
+    test_knn_inv()
     results = benchmark_knn_inv(
                     point_sizes=[25000, 50000, 100000, 200000],
                     k_values=[16, 32, 64, 128],
@@ -1449,10 +1449,10 @@ if __name__ == "__main__":
     )
     plot_knn_inv_benchmark(results)
 
-    # test_pconv_linear_opt()
-    # results = test_pconv_linear_opt_random(
-    #                 point_sizes=[25000, 50000, 100000, 200000],
-    #                 K=64,
-    #                 num_runs=3
-    # )
-    # plot_pconv_linear_opt_benchmark(results)
+    test_pconv_linear_opt()
+    results = test_pconv_linear_opt_random(
+                    point_sizes=[25000, 50000, 100000, 200000],
+                    K=64,
+                    num_runs=3
+    )
+    plot_pconv_linear_opt_benchmark(results)

--- a/cpp_wrappers/cpp_pcf_kernel/test_kernels.py
+++ b/cpp_wrappers/cpp_pcf_kernel/test_kernels.py
@@ -377,7 +377,7 @@ def test_knn_inv():
         Compare outputs by sorting pairs within each segment defined by inv_idx
         """
         cuda_neighbors = cuda_neighbors.cpu().numpy()
-        cuda_k = cuda_k.cpu().numpy()
+        cuda_k = cuda_k.to(torch.int32).cpu().numpy()
         py_neighbors = py_neighbors.cpu().numpy()
         py_k = py_k.cpu().numpy()
         inv_idx = inv_idx.cpu().numpy()

--- a/cpp_wrappers/cpp_pcf_kernel/test_kernels.py
+++ b/cpp_wrappers/cpp_pcf_kernel/test_kernels.py
@@ -411,9 +411,9 @@ def test_knn_inv():
 
 
     B = 4          # batch size (meh!!)
-    N = 100000        # number of points 
+    N = 200000        # number of points 
     C_in = 3        # number of inp channels
-    K = 100          # number of neighbors
+    K = 64         # number of neighbors
     total_points = N
     num_runs = 100
 

--- a/scannet_data_loader_color_DDP.py
+++ b/scannet_data_loader_color_DDP.py
@@ -165,9 +165,9 @@ class ScanNetDataset(Dataset):
         return self.data[indx][3]
 
     def __getitem__(self, indx):
-        coord, features, label, _ = self.data[indx]
+        coord, color, label, norm = self.data[indx]
 
-        color, norm = features[:, :3], features[:, 3:]
+        # color, norm = features[:, :3], features[:, 3:]
 
         # move z to 0+
         z_min = coord[:, 2].min()

--- a/train_ScanNet_DDP_WarmUP.py
+++ b/train_ScanNet_DDP_WarmUP.py
@@ -605,6 +605,9 @@ def validate(val_loader, model, criterion):
                     loss_meter=loss_meter,
                     accuracy=accuracy))
 
+        del inv_self, inv_forward, inv_propagate
+        del pred, loss, output, intersection, union, target
+
     iou_class = intersection_meter.sum / (union_meter.sum + 1e-10)
     # print('iou_class : ', iou_class)
     accuracy_class = intersection_meter.sum / (target_meter.sum + 1e-10)

--- a/util/common_util.py
+++ b/util/common_util.py
@@ -248,6 +248,31 @@ def replace_batchnorm(net):
 
 
 def compute_knn_inverse(pointclouds, edges_self, edges_forward, edges_propagate):
+    """
+    Compute inverse k-nearest neighbor mappings for self, forward, and propagate edges using pcf_cuda
+
+    Parameters
+    ----------
+    pointclouds : list of Tensor
+        List of point cloud tensors at each level. Each tensor has shape [B, N, ...],
+        where N is the number of points.
+    edges_self : list of Tensor
+        Each element is a [B, k] tensor of neighbor indices for self edges at each level.
+    edges_forward : list of Tensor
+        Each element is a [B, k] tensor of neighbor indices mapping from current to next level.
+    edges_propagate : list of Tensor
+        Each element is a [B, k] tensor of neighbor indices for propagation edges at each level.
+
+    Returns
+    -------
+    inv_self : list
+        [inverse_neighbors_self, inverse_k_self, inverse_idx_self], each a list of Tensors
+        mapping back from neighbor to point indices for self edges.
+    inv_forward : list
+        [inverse_neighbors_forward, inverse_k_forward, inverse_idx_forward] for forward edges.
+    inv_propagate : list
+        [inverse_neighbors_propagate, inverse_k_propagate, inverse_idx_propagate] for propagate edges.
+    """
     import pcf_cuda
 
     inverse_neighbors_self = []


### PR DESCRIPTION
This branch changes includes:

1. PointConv + Linear Layer fused kernels for forward and backward.
2. KNN Inverse Indices computation kernel.
3. Optimized fused backward kernel using Inverse Indices.
4. Optimized fused cutlass forward kernel.
5. Tests for Performance analysis.
6. Integration with existing model architecture.
7. To enable Optimized kernels, set `USE_CUDA_KERNEL: True` and `PCONV_OPT: True` in the config file. Refer configs/configPCF_Opt_10cm.yaml

Cutlass forward kernel is not yet integrated into model architecture (more optimization work to be done here).

Below Profiles are with H100 GPU, CUDA 11.8, Cutlass 3.x.

For kernel profilings, refer this log. This is for single run, so the kernel launch overhead is significant. But, it's good to look at grid and block sizes for all the kernels in a single place.
[pconv_nvtx_log.txt](https://github.com/user-attachments/files/19699228/pconv_nvtx_log.txt)


For plots profiling runtime and memory usage averaged across 50 runs:
Profile of Unfused vs. Fused vs. Fused using KNN Inverse Indices kernels:
![pconv_benchmark_results](https://github.com/user-attachments/assets/62de53c2-8cd0-4102-8821-054c06b0d7a9)
![pconv_benchmark_speedup](https://github.com/user-attachments/assets/ebddb7ac-392c-486d-96a3-def26a1b297b)


Profile of KNN Inverse Indices kernel:
![knn_inv_benchmark_results](https://github.com/user-attachments/assets/16e9b330-eff6-4f39-8fc6-9c635ad3f43c)
![knn_inv_k_scaling](https://github.com/user-attachments/assets/1e70ac50-fc3d-4c7e-9d7b-a05d6f313f67)

To-Dos:
1. Optimize memory usage of cutlass forward kernel.
2. Adapt Fused backward Pure CUDA kernel to cutlass.
